### PR TITLE
fix(ui): allow Universal Clipboard for bunker URI copy

### DIFF
--- a/Clave/Views/Home/ConnectSheet.swift
+++ b/Clave/Views/Home/ConnectSheet.swift
@@ -115,13 +115,17 @@ struct ConnectSheet: View {
 
             HStack(spacing: 12) {
                 Button {
-                    // Local-only + 120s expiration: the bunker URI embeds the active pairing
-                    // secret, so don't sync via Universal Clipboard and auto-clear after 2 min
-                    // (audit finding A10.2).
+                    // 120s expiration: the bunker URI embeds the active pairing secret, so
+                    // auto-clear after 2 min. Universal Clipboard is intentionally allowed
+                    // here — pairing a Mac browser client (Coracle, noStrudel, etc.) from
+                    // the iPhone bunker URI is the primary cross-device UX path. Audit
+                    // finding A10.2 (originally applied `localOnly: true` to both nsec and
+                    // bunker URI) scope is now reduced to nsec only; nsec export in
+                    // `ExportKeySheet.swift` remains `localOnly: true` (raw private key,
+                    // non-negotiable).
                     UIPasteboard.general.setItems(
                         [["public.utf8-plain-text": appState.bunkerURI]],
                         options: [
-                            .localOnly: true,
                             .expirationDate: Date().addingTimeInterval(120)
                         ]
                     )


### PR DESCRIPTION
## Summary
- Drops `.localOnly: true` from the bunker URI copy in `ConnectSheet.swift` (keeps the 120s expiration).
- Nsec export in `ExportKeySheet.swift` stays `localOnly: true` (raw private key, non-negotiable).
- Enables Universal Clipboard for the primary cross-device pairing UX: copy bunker URI on iPhone → paste into Mac browser client (Coracle, noStrudel, etc.).

## Why
Audit finding A10.2 originally locked both nsec and bunker URI to `localOnly: true` to prevent Universal Clipboard leakage. For the bunker URI that turned out to defeat the main cross-device pairing flow — users resort to AirDrop or manual retype, or silently fail (clipboard shows stale content on Mac).

## Expiration behavior (important caveat)

The 120s `.expirationDate` **fires on iPhone only**. Universal Clipboard does not propagate expiration metadata to Mac-side NSPasteboard, so the Mac clipboard stays populated until the user next copies something on any UC-connected device. Apple provides no cross-device expiration API.

Residual exposure on the Mac is bounded by `SharedStorage.rotateBunkerSecret()` firing on successful pair — once any client pairs with the secret, any stale clipboard copies become dead weight (the secret is single-use). Audit note at `~/hq/clave/security-audits/2026-04-17-pre-external-testflight.md` A10.2 updated to reflect this.

## Test plan
- [x] Xcode build clean (same pre-existing Sendable warnings from PR #4, no new issues)
- [x] Copy bunker URI on iPhone → paste into Mac browser → URI appears (verified on build 20)
- [x] Coracle bunker via Mac paste → login completes
- [x] noStrudel bunker via Mac paste → login completes
- [x] Nsec export → Mac clipboard stays empty (localOnly still enforced on nsec)
- [x] iPhone-side: 120s expiration fires (paste on iPhone after 2min shows empty)
- [ ] Mac-side: does NOT auto-clear at 120s (documented limitation, not a bug)

## Related
- BACKLOG → High Priority → "Allow Universal Clipboard for bunker URI copy" (this PR resolves it)
- Fix is also cherry-picked onto [clave#7](https://github.com/DocNR/clave/pull/7) for combined device testing in build 20. Depending on merge order, either this PR merges first and #7 rebases, or #7 merges with the bundled fix and this PR is closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)