### PR TITLE
feat: proxy-per-client-relay V2 (unblocks external past build 18)

### DIFF
--- a/Clave/AppState.swift
+++ b/Clave/AppState.swift
@@ -696,20 +696,35 @@ final class AppState {
     }
 
     private func retryPairOp(op: PairOp, relayUrls: [String]) {
-        guard let nsec = SharedKeychain.loadNsec() else { return }
+        // No-nsec / setup-failure early returns: remove the op rather than let it
+        // sit forever. A PairOp without a signable key is meaningless — the op
+        // was queued before a key rotation or delete.
+        guard let nsec = SharedKeychain.loadNsec() else {
+            SharedStorage.removePendingPairOp(id: op.id)
+            return
+        }
         let privateKey: Data
-        do { privateKey = try Bech32.decodeNsec(nsec) } catch { return }
+        do { privateKey = try Bech32.decodeNsec(nsec) } catch {
+            SharedStorage.removePendingPairOp(id: op.id)
+            return
+        }
 
         let proxyURL = SharedConstants.sharedDefaults.string(forKey: SharedConstants.proxyURLKey)
             ?? SharedConstants.defaultProxyURL
         let pairURL = "\(proxyURL)/pair-client"
-        guard let url = URL(string: pairURL) else { return }
+        guard let url = URL(string: pairURL) else {
+            SharedStorage.removePendingPairOp(id: op.id)
+            return
+        }
 
         let bodyDict: [String: Any] = [
             "client_pubkey": op.clientPubkey,
             "relay_urls": relayUrls
         ]
-        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else { return }
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else {
+            SharedStorage.removePendingPairOp(id: op.id)
+            return
+        }
         let bodyHash = SHA256.hash(data: bodyData).map { String(format: "%02x", $0) }.joined()
 
         let authHeader: String
@@ -720,7 +735,10 @@ final class AppState {
                 method: "POST",
                 bodySha256Hex: bodyHash
             )
-        } catch { return }
+        } catch {
+            SharedStorage.bumpPendingPairOpFailCount(id: op.id)
+            return
+        }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -740,17 +758,29 @@ final class AppState {
     }
 
     private func retryUnpairOp(op: PairOp) {
-        guard let nsec = SharedKeychain.loadNsec() else { return }
+        guard let nsec = SharedKeychain.loadNsec() else {
+            SharedStorage.removePendingPairOp(id: op.id)
+            return
+        }
         let privateKey: Data
-        do { privateKey = try Bech32.decodeNsec(nsec) } catch { return }
+        do { privateKey = try Bech32.decodeNsec(nsec) } catch {
+            SharedStorage.removePendingPairOp(id: op.id)
+            return
+        }
 
         let proxyURL = SharedConstants.sharedDefaults.string(forKey: SharedConstants.proxyURLKey)
             ?? SharedConstants.defaultProxyURL
         let unpairURL = "\(proxyURL)/unpair-client"
-        guard let url = URL(string: unpairURL) else { return }
+        guard let url = URL(string: unpairURL) else {
+            SharedStorage.removePendingPairOp(id: op.id)
+            return
+        }
 
         let bodyDict: [String: Any] = ["client_pubkey": op.clientPubkey]
-        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else { return }
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else {
+            SharedStorage.removePendingPairOp(id: op.id)
+            return
+        }
         let bodyHash = SHA256.hash(data: bodyData).map { String(format: "%02x", $0) }.joined()
 
         let authHeader: String
@@ -761,7 +791,10 @@ final class AppState {
                 method: "POST",
                 bodySha256Hex: bodyHash
             )
-        } catch { return }
+        } catch {
+            SharedStorage.bumpPendingPairOpFailCount(id: op.id)
+            return
+        }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"

--- a/Clave/AppState.swift
+++ b/Clave/AppState.swift
@@ -379,6 +379,16 @@ final class AppState {
                     )
                     SharedStorage.logActivity(entry)
                     activityLogged = true
+
+                    // Tell the proxy about this pair so it opens secondary subs
+                    // on the URI relays. Best-effort — failures queue for retry
+                    // via SharedStorage.pendingPairOps.
+                    if success {
+                        pairClientWithProxy(
+                            clientPubkey: parsedURI.clientPubkey,
+                            relayUrls: parsedURI.relays
+                        )
+                    }
                 }
             }
 
@@ -525,6 +535,120 @@ final class AppState {
         request.httpBody = bodyData
 
         URLSession.shared.dataTask(with: request) { _, _, _ in }.resume()
+    }
+
+    // MARK: - Proxy per-client-relay (V2)
+
+    /// Notify the proxy of a nostrconnect pair so it can open secondary relay
+    /// subscriptions. Fire-and-forget from the caller's perspective; failures
+    /// are queued in SharedStorage.pendingPairOps for later retry.
+    func pairClientWithProxy(clientPubkey: String, relayUrls: [String]) {
+        guard let nsec = SharedKeychain.loadNsec() else { return }
+        let privateKey: Data
+        do {
+            privateKey = try Bech32.decodeNsec(nsec)
+        } catch {
+            return
+        }
+
+        let proxyURL = SharedConstants.sharedDefaults.string(forKey: SharedConstants.proxyURLKey)
+            ?? SharedConstants.defaultProxyURL
+        let pairURL = "\(proxyURL)/pair-client"
+        guard let url = URL(string: pairURL) else { return }
+
+        let bodyDict: [String: Any] = [
+            "client_pubkey": clientPubkey,
+            "relay_urls": relayUrls
+        ]
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else { return }
+        let bodyHash = SHA256.hash(data: bodyData).map { String(format: "%02x", $0) }.joined()
+
+        let authHeader: String
+        do {
+            authHeader = try LightEvent.signNip98(
+                privateKey: privateKey,
+                url: pairURL,
+                method: "POST",
+                bodySha256Hex: bodyHash
+            )
+        } catch {
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 10
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(authHeader, forHTTPHeaderField: "X-Clave-Auth")
+        request.httpBody = bodyData
+
+        URLSession.shared.dataTask(with: request) { _, response, _ in
+            let http = response as? HTTPURLResponse
+            if http?.statusCode == 200 { return }
+            // Any non-200 (including network error → http == nil) queues for retry.
+            let op = PairOp(
+                id: UUID().uuidString,
+                kind: .pair,
+                clientPubkey: clientPubkey,
+                relayUrls: relayUrls,
+                createdAt: Date().timeIntervalSince1970,
+                failCount: 0
+            )
+            SharedStorage.enqueuePendingPairOp(op)
+        }.resume()
+    }
+
+    /// Notify the proxy of an unpair. Same failure semantics as pair.
+    func unpairClientWithProxy(clientPubkey: String) {
+        guard let nsec = SharedKeychain.loadNsec() else { return }
+        let privateKey: Data
+        do {
+            privateKey = try Bech32.decodeNsec(nsec)
+        } catch {
+            return
+        }
+
+        let proxyURL = SharedConstants.sharedDefaults.string(forKey: SharedConstants.proxyURLKey)
+            ?? SharedConstants.defaultProxyURL
+        let unpairURL = "\(proxyURL)/unpair-client"
+        guard let url = URL(string: unpairURL) else { return }
+
+        let bodyDict: [String: Any] = ["client_pubkey": clientPubkey]
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else { return }
+        let bodyHash = SHA256.hash(data: bodyData).map { String(format: "%02x", $0) }.joined()
+
+        let authHeader: String
+        do {
+            authHeader = try LightEvent.signNip98(
+                privateKey: privateKey,
+                url: unpairURL,
+                method: "POST",
+                bodySha256Hex: bodyHash
+            )
+        } catch {
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 10
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(authHeader, forHTTPHeaderField: "X-Clave-Auth")
+        request.httpBody = bodyData
+
+        URLSession.shared.dataTask(with: request) { _, response, _ in
+            let http = response as? HTTPURLResponse
+            if http?.statusCode == 200 { return }
+            let op = PairOp(
+                id: UUID().uuidString,
+                kind: .unpair,
+                clientPubkey: clientPubkey,
+                relayUrls: nil,
+                createdAt: Date().timeIntervalSince1970,
+                failCount: 0
+            )
+            SharedStorage.enqueuePendingPairOp(op)
+        }.resume()
     }
 
     // MARK: - Multi-relay helpers (nostrconnect handshake)

--- a/Clave/AppState.swift
+++ b/Clave/AppState.swift
@@ -35,6 +35,18 @@ final class AppState {
     var profile: CachedProfile?
     var profileImage: UIImage?
 
+    init() {
+        // Drain the /pair-client retry queue on every app foreground. The
+        // AppDelegate posts .drainPendingPairOps from applicationDidBecomeActive.
+        NotificationCenter.default.addObserver(
+            forName: .drainPendingPairOps,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.drainPendingPairOps()
+        }
+    }
+
     var npub: String {
         guard !signerPubkeyHex.isEmpty,
               let pubkey = try? PublicKey.parse(publicKey: signerPubkeyHex) else { return "" }
@@ -215,6 +227,13 @@ final class AppState {
 
     func deleteKey() {
         // Unregister BEFORE wiping the keychain — needs the nsec to sign the NIP-98 header.
+        // Also bulk-unpair every known client first (best-effort) so the proxy releases its
+        // secondary relay refs. Any failures become 90-day-GC'd orphans on the proxy.
+        let clientsToUnpair = SharedStorage.getConnectedClients()
+        for client in clientsToUnpair {
+            unpairClientWithProxy(clientPubkey: client.pubkey)
+        }
+        SharedStorage.clearPendingPairOps()  // nuking the key; drop any queued ops
         unregisterWithProxy()
         SharedKeychain.deleteNsec()
         SharedConstants.sharedDefaults.removeObject(forKey: SharedConstants.signerPubkeyHexKey)
@@ -478,9 +497,10 @@ final class AppState {
         request.setValue(authHeader, forHTTPHeaderField: "X-Clave-Auth")
         request.httpBody = bodyData
 
-        URLSession.shared.dataTask(with: request) { _, response, error in
+        URLSession.shared.dataTask(with: request) { [weak self] _, response, error in
             DispatchQueue.main.async {
                 if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                    self?.drainPendingPairOps()
                     completion?(true, "Registered")
                 } else if let http = response as? HTTPURLResponse {
                     completion?(false, "Failed: HTTP \(http.statusCode)")
@@ -648,6 +668,115 @@ final class AppState {
                 failCount: 0
             )
             SharedStorage.enqueuePendingPairOp(op)
+        }.resume()
+    }
+
+    /// Drain the pending pair/unpair ops queue. Called on app foreground and
+    /// after successful /register. Each op is retried once per drain attempt;
+    /// ops that fail 3 times are removed.
+    func drainPendingPairOps() {
+        let ops = SharedStorage.getPendingPairOps()
+        guard !ops.isEmpty else { return }
+        for op in ops {
+            if op.failCount >= 3 {
+                SharedStorage.removePendingPairOp(id: op.id)
+                continue
+            }
+            switch op.kind {
+            case .pair:
+                if let relays = op.relayUrls {
+                    retryPairOp(op: op, relayUrls: relays)
+                } else {
+                    SharedStorage.removePendingPairOp(id: op.id)
+                }
+            case .unpair:
+                retryUnpairOp(op: op)
+            }
+        }
+    }
+
+    private func retryPairOp(op: PairOp, relayUrls: [String]) {
+        guard let nsec = SharedKeychain.loadNsec() else { return }
+        let privateKey: Data
+        do { privateKey = try Bech32.decodeNsec(nsec) } catch { return }
+
+        let proxyURL = SharedConstants.sharedDefaults.string(forKey: SharedConstants.proxyURLKey)
+            ?? SharedConstants.defaultProxyURL
+        let pairURL = "\(proxyURL)/pair-client"
+        guard let url = URL(string: pairURL) else { return }
+
+        let bodyDict: [String: Any] = [
+            "client_pubkey": op.clientPubkey,
+            "relay_urls": relayUrls
+        ]
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else { return }
+        let bodyHash = SHA256.hash(data: bodyData).map { String(format: "%02x", $0) }.joined()
+
+        let authHeader: String
+        do {
+            authHeader = try LightEvent.signNip98(
+                privateKey: privateKey,
+                url: pairURL,
+                method: "POST",
+                bodySha256Hex: bodyHash
+            )
+        } catch { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 10
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(authHeader, forHTTPHeaderField: "X-Clave-Auth")
+        request.httpBody = bodyData
+
+        URLSession.shared.dataTask(with: request) { _, response, _ in
+            let http = response as? HTTPURLResponse
+            if http?.statusCode == 200 {
+                SharedStorage.removePendingPairOp(id: op.id)
+            } else {
+                SharedStorage.bumpPendingPairOpFailCount(id: op.id)
+            }
+        }.resume()
+    }
+
+    private func retryUnpairOp(op: PairOp) {
+        guard let nsec = SharedKeychain.loadNsec() else { return }
+        let privateKey: Data
+        do { privateKey = try Bech32.decodeNsec(nsec) } catch { return }
+
+        let proxyURL = SharedConstants.sharedDefaults.string(forKey: SharedConstants.proxyURLKey)
+            ?? SharedConstants.defaultProxyURL
+        let unpairURL = "\(proxyURL)/unpair-client"
+        guard let url = URL(string: unpairURL) else { return }
+
+        let bodyDict: [String: Any] = ["client_pubkey": op.clientPubkey]
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else { return }
+        let bodyHash = SHA256.hash(data: bodyData).map { String(format: "%02x", $0) }.joined()
+
+        let authHeader: String
+        do {
+            authHeader = try LightEvent.signNip98(
+                privateKey: privateKey,
+                url: unpairURL,
+                method: "POST",
+                bodySha256Hex: bodyHash
+            )
+        } catch { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 10
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(authHeader, forHTTPHeaderField: "X-Clave-Auth")
+        request.httpBody = bodyData
+
+        URLSession.shared.dataTask(with: request) { _, response, _ in
+            let http = response as? HTTPURLResponse
+            if http?.statusCode == 200 {
+                SharedStorage.removePendingPairOp(id: op.id)
+            } else {
+                SharedStorage.bumpPendingPairOpFailCount(id: op.id)
+            }
         }.resume()
     }
 

--- a/Clave/ClaveApp.swift
+++ b/Clave/ClaveApp.swift
@@ -146,7 +146,8 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                 do {
                     let result = try await LightSigner.handleRequest(
                         privateKey: privateKey,
-                        requestEvent: event
+                        requestEvent: event,
+                        responseRelayUrl: relayUrlString
                     )
                     processedIDs.insert(eventId)
                     if result.status == "error" && result.errorMessage == "Decrypt failed" {

--- a/Clave/ClaveApp.swift
+++ b/Clave/ClaveApp.swift
@@ -55,6 +55,12 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         logger.error("[APNs] Failed to register: \(error.localizedDescription)")
     }
 
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Drain the pair/unpair retry queue. AppState listens for this and
+        // processes pendingPairOps.
+        NotificationCenter.default.post(name: .drainPendingPairOps, object: nil)
+    }
+
     // MARK: - Foreground Push Handling
 
     func userNotificationCenter(
@@ -180,4 +186,5 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 
 extension Notification.Name {
     static let signingCompleted = Notification.Name("signingCompleted")
+    static let drainPendingPairOps = Notification.Name("drainPendingPairOps")
 }

--- a/Clave/Views/Home/ApprovalSheet.swift
+++ b/Clave/Views/Home/ApprovalSheet.swift
@@ -8,6 +8,7 @@ struct ApprovalSheet: View {
     @State private var selectedTrust: TrustLevel
     @State private var kindOverrides: [Int: Bool] = [:]
     @State private var showPermissions = false
+    @State private var capExceeded = false
 
     private let protectedKinds: Set<Int> = SharedStorage.getProtectedKinds()
 
@@ -30,6 +31,11 @@ struct ApprovalSheet: View {
             }
             .navigationTitle("Approve Connection")
             .navigationBarTitleDisplayMode(.inline)
+            .alert("Free tier limit reached", isPresented: $capExceeded) {
+                Button("OK", role: .cancel) { }
+            } message: {
+                Text("You've paired the maximum 5 clients. Unpair one from Settings → Clients to continue.")
+            }
         }
     }
 
@@ -234,6 +240,16 @@ struct ApprovalSheet: View {
     }
 
     private func buildAndApprove() {
+        // Free-tier cap: 5 paired clients total (bunker + nostrconnect combined).
+        // Counts the union in SharedStorage.connectedClients. Re-pairing an
+        // existing client (same pubkey) isn't blocked since no new row is added.
+        let connected = SharedStorage.getConnectedClients()
+        let alreadyPaired = connected.contains { $0.pubkey == parsedURI.clientPubkey }
+        if !alreadyPaired && connected.count >= 5 {
+            capExceeded = true
+            return
+        }
+
         let permissions = ClientPermissions(
             pubkey: parsedURI.clientPubkey,
             trustLevel: selectedTrust,

--- a/Clave/Views/Home/ClientDetailView.swift
+++ b/Clave/Views/Home/ClientDetailView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ClientDetailView: View {
     let pubkey: String
 
+    @Environment(AppState.self) private var appState
     @State private var permissions: ClientPermissions?
     @State private var selectedTrust: TrustLevel = .medium
     @State private var kindOverrides: [Int: Bool] = [:]
@@ -407,6 +408,7 @@ struct ClientDetailView: View {
     }
 
     private func performUnpair() {
+        appState.unpairClientWithProxy(clientPubkey: pubkey)
         SharedStorage.removeClientPermissions(for: pubkey)
         dismiss()
     }

--- a/Clave/Views/Home/HomeView.swift
+++ b/Clave/Views/Home/HomeView.swift
@@ -60,11 +60,12 @@ struct HomeView: View {
                             NavigationLink(destination: ClientDetailView(pubkey: client.pubkey)) {
                                 clientRow(client)
                             }
-                        }
-                        .onDelete { indexSet in
-                            for index in indexSet {
-                                let client = sortedClients[index]
-                                clientToUnpair = client
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button(role: .destructive) {
+                                    clientToUnpair = client
+                                } label: {
+                                    Label("Unpair", systemImage: "trash")
+                                }
                             }
                         }
                     }

--- a/Clave/Views/Home/HomeView.swift
+++ b/Clave/Views/Home/HomeView.swift
@@ -105,6 +105,7 @@ struct HomeView: View {
                 Button("Unpair", role: .destructive) {
                     if let client = clientToUnpair {
                         withAnimation {
+                            appState.unpairClientWithProxy(clientPubkey: client.pubkey)
                             SharedStorage.removeClientPermissions(for: client.pubkey)
                             refreshData()
                         }

--- a/ClaveNSE/NotificationService.swift
+++ b/ClaveNSE/NotificationService.swift
@@ -169,7 +169,8 @@ class NotificationService: UNNotificationServiceExtension {
                 do {
                     let result = try await LightSigner.handleRequest(
                         privateKey: privateKey,
-                        requestEvent: event
+                        requestEvent: event,
+                        responseRelayUrl: relayUrlString
                     )
                     processedIDs.insert(eventId)
                     // Decrypt failures mean "not for us" — skip silently

--- a/ClaveTests/LightSignerResponseRelayUrlTests.swift
+++ b/ClaveTests/LightSignerResponseRelayUrlTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import Clave
+
+/// Tests that LightSigner.handleRequest honors the responseRelayUrl parameter
+/// (the probe E fix). Without this, the NSE fallback publishes signed responses
+/// to SharedConstants.relayURL regardless of where the request came from, which
+/// breaks end-to-end signing for any client whose URI doesn't include
+/// relay.powr.build.
+///
+/// We can't easily intercept LightRelay inside handleRequest without a larger
+/// refactor, so this file focuses on compile-time assertions (the signature
+/// change itself is the fix; runtime behavior is covered by the device
+/// verification matrix).
+final class LightSignerResponseRelayUrlTests: XCTestCase {
+
+    /// Compile-time check: handleRequest accepts responseRelayUrl.
+    /// If this file fails to compile, the signature regressed.
+    func testHandleRequestAcceptsResponseRelayUrl() async throws {
+        let dummyKey = Data(repeating: 0, count: 32)
+        let dummyEvent: [String: Any] = [
+            "id": "deadbeef",
+            "pubkey": "0".padding(toLength: 64, withPad: "0", startingAt: 0),
+            "content": "not-a-valid-ciphertext",
+            "kind": 24133,
+            "tags": [],
+        ]
+        // We don't care about the result — we care that this compiles with
+        // `responseRelayUrl:` in the argument list.
+        _ = try? await LightSigner.handleRequest(
+            privateKey: dummyKey,
+            requestEvent: dummyEvent,
+            responseRelayUrl: "wss://bucket.coracle.social"
+        )
+        XCTAssertTrue(true)
+    }
+
+    /// Compile-time check: responseRelayUrl is optional and defaults to nil.
+    /// Call sites that don't care about V2 (existing code paths) must still
+    /// compile unchanged.
+    func testHandleRequestResponseRelayUrlIsOptional() async throws {
+        let dummyKey = Data(repeating: 0, count: 32)
+        let dummyEvent: [String: Any] = ["content": ""]
+        _ = try? await LightSigner.handleRequest(
+            privateKey: dummyKey,
+            requestEvent: dummyEvent
+            // no responseRelayUrl — must still compile
+        )
+        XCTAssertTrue(true)
+    }
+}

--- a/Shared/LightSigner.swift
+++ b/Shared/LightSigner.swift
@@ -17,7 +17,8 @@ enum LightSigner {
         privateKey: Data,
         requestEvent: [String: Any],
         skipProtection: Bool = false,
-        responseRelays: [LightRelay]? = nil
+        responseRelays: [LightRelay]? = nil,
+        responseRelayUrl: String? = nil
     ) async throws -> RequestResult {
         guard let senderPubkey = requestEvent["pubkey"] as? String,
               let encryptedContent = requestEvent["content"] as? String else {
@@ -108,7 +109,8 @@ enum LightSigner {
                     requestId: requestId, error: "Invalid or missing bunker secret",
                     privateKey: privateKey, senderPubkeyData: senderPubkeyData,
                     senderPubkey: senderPubkey, isNip04: isNip04,
-                    responseRelays: responseRelays
+                    responseRelays: responseRelays,
+                    responseRelayUrl: responseRelayUrl
                 )
                 return result
             }
@@ -132,7 +134,8 @@ enum LightSigner {
                     requestId: requestId, error: "Client not paired — send connect with valid bunker secret first",
                     privateKey: privateKey, senderPubkeyData: senderPubkeyData,
                     senderPubkey: senderPubkey, isNip04: isNip04,
-                    responseRelays: responseRelays
+                    responseRelays: responseRelays,
+                    responseRelayUrl: responseRelayUrl
                 )
                 return result
             }
@@ -184,7 +187,8 @@ enum LightSigner {
                         requestId: requestId, error: "Permission denied — open Clave to approve",
                         privateKey: privateKey, senderPubkeyData: senderPubkeyData,
                         senderPubkey: senderPubkey, isNip04: isNip04,
-                        responseRelays: responseRelays
+                        responseRelays: responseRelays,
+                        responseRelayUrl: responseRelayUrl
                     )
                     return result
                 }
@@ -250,8 +254,11 @@ enum LightSigner {
             // Best-effort — accepted if at least one relay took the event.
             accepted = await publishResponseToRelays(responseRelays, event: eventDict)
         } else {
-            // Bunker/NSE path: publish to the signer's primary relay (relay.powr.build).
-            let relay = LightRelay(url: SharedConstants.relayURL)
+            // Bunker/NSE path: publish to the relay the request came in on
+            // (origin relay from push payload), falling back to the primary
+            // relay for handshake paths that don't have an origin yet.
+            let relayUrlString = responseRelayUrl ?? SharedConstants.relayURL
+            let relay = LightRelay(url: relayUrlString)
             try await relay.connect(timeout: 5.0)
             accepted = (try? await relay.publishEvent(event: eventDict)) ?? false
             relay.disconnect()
@@ -422,7 +429,8 @@ enum LightSigner {
         requestId: String, error: String,
         privateKey: Data, senderPubkeyData: Data,
         senderPubkey: String, isNip04: Bool,
-        responseRelays: [LightRelay]? = nil
+        responseRelays: [LightRelay]? = nil,
+        responseRelayUrl: String? = nil
     ) async throws {
         let responseDict: [String: Any] = ["id": requestId, "error": error]
         guard let responseData = try? JSONSerialization.data(withJSONObject: responseDict),
@@ -444,7 +452,8 @@ enum LightSigner {
         if let responseRelays = responseRelays, !responseRelays.isEmpty {
             _ = await publishResponseToRelays(responseRelays, event: eventDict)
         } else {
-            let relay = LightRelay(url: SharedConstants.relayURL)
+            let relayUrlString = responseRelayUrl ?? SharedConstants.relayURL
+            let relay = LightRelay(url: relayUrlString)
             try await relay.connect(timeout: 5.0)
             _ = try? await relay.publishEvent(event: eventDict)
             relay.disconnect()

--- a/Shared/LightSigner.swift
+++ b/Shared/LightSigner.swift
@@ -76,8 +76,30 @@ enum LightSigner {
             let expectedSecret = SharedStorage.getBunkerSecret()
 
             if !providedSecret.isEmpty && providedSecret == expectedSecret {
-                // Valid secret — create permissions if new, then rotate secret
-                if SharedStorage.getClientPermissions(for: senderPubkey) == nil {
+                // Valid secret — check cap before creating new permissions
+                let isExistingClient = SharedStorage.getClientPermissions(for: senderPubkey) != nil
+                if !isExistingClient {
+                    let currentCount = SharedStorage.getConnectedClients().count
+                    if currentCount >= 5 {
+                        logger.notice("[LightSigner] Bunker connect rejected: pairing cap reached (5)")
+                        let result = RequestResult(
+                            method: method, eventKind: nil, clientPubkey: senderPubkey,
+                            status: "blocked", errorMessage: "Pairing limit reached (5)"
+                        )
+                        logAndTrack(result: result, clientName: clientName)
+                        try await sendErrorResponse(
+                            requestId: requestId,
+                            error: "Pairing limit reached. Unpair an existing client in Clave settings.",
+                            privateKey: privateKey, senderPubkeyData: senderPubkeyData,
+                            senderPubkey: senderPubkey, isNip04: isNip04,
+                            responseRelays: responseRelays,
+                            responseRelayUrl: responseRelayUrl
+                        )
+                        return result
+                    }
+                }
+
+                if !isExistingClient {
                     let perms = ClientPermissions(
                         pubkey: senderPubkey,
                         trustLevel: .medium,

--- a/Shared/SharedConstants.swift
+++ b/Shared/SharedConstants.swift
@@ -17,6 +17,7 @@ enum SharedConstants {
     static let blockedKindsKey = "blockedKinds"
     static let autoSignKey = "autoSignEnabled"
     static let pendingRequestsKey = "pendingRequests"
+    static let pendingPairOpsKey = "pendingPairOps"
     static let bunkerSecretKey = "bunkerSecret"
     static let pairedClientsKey = "pairedClients"
     static let clientPermissionsKey = "clientPermissions"

--- a/Shared/SharedModels.swift
+++ b/Shared/SharedModels.swift
@@ -27,4 +27,68 @@ struct ConnectedClient: Codable, Identifiable {
     let firstSeen: Double
     var lastSeen: Double
     var requestCount: Int
+    /// URI relays from the nostrconnect pair (empty for bunker pairings and
+    /// for existing pre-V2 rows). Mirrored to the proxy's `/pair-client`
+    /// payload and used to know which relays to tell the proxy about on
+    /// retry.
+    var relayUrls: [String] = []
+
+    // Explicit Codable implementation so decoding existing rows without
+    // `relayUrls` succeeds (Codable's default synthesis doesn't honor the
+    // property default value when the key is absent in the JSON).
+    private enum CodingKeys: String, CodingKey {
+        case pubkey, name, firstSeen, lastSeen, requestCount, relayUrls
+    }
+
+    init(
+        pubkey: String,
+        name: String? = nil,
+        firstSeen: Double,
+        lastSeen: Double,
+        requestCount: Int,
+        relayUrls: [String] = []
+    ) {
+        self.pubkey = pubkey
+        self.name = name
+        self.firstSeen = firstSeen
+        self.lastSeen = lastSeen
+        self.requestCount = requestCount
+        self.relayUrls = relayUrls
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        pubkey = try container.decode(String.self, forKey: .pubkey)
+        name = try container.decodeIfPresent(String.self, forKey: .name)
+        firstSeen = try container.decode(Double.self, forKey: .firstSeen)
+        lastSeen = try container.decode(Double.self, forKey: .lastSeen)
+        requestCount = try container.decode(Int.self, forKey: .requestCount)
+        relayUrls = try container.decodeIfPresent([String].self, forKey: .relayUrls) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(pubkey, forKey: .pubkey)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encode(firstSeen, forKey: .firstSeen)
+        try container.encode(lastSeen, forKey: .lastSeen)
+        try container.encode(requestCount, forKey: .requestCount)
+        try container.encode(relayUrls, forKey: .relayUrls)
+    }
+}
+
+/// Queued pair/unpair operation awaiting delivery to the proxy.
+/// Persisted in SharedStorage.pendingPairOps. FIFO, cap 10, drop-oldest on
+/// overflow. Drained on applicationDidBecomeActive and after /register success.
+struct PairOp: Codable, Identifiable {
+    enum Kind: String, Codable {
+        case pair
+        case unpair
+    }
+    let id: String              // UUID
+    let kind: Kind
+    let clientPubkey: String
+    let relayUrls: [String]?    // present for .pair, nil for .unpair
+    let createdAt: Double
+    var failCount: Int          // internal only — used for backoff cap
 }

--- a/Shared/SharedStorage.swift
+++ b/Shared/SharedStorage.swift
@@ -85,6 +85,39 @@ enum SharedStorage {
         defaults.removeObject(forKey: SharedConstants.pendingRequestsKey)
     }
 
+    // MARK: - Pending Pair Ops (HTTP failure retry queue)
+
+    /// Queue an operation to be retried on next drain. FIFO, cap 10 — drops
+    /// oldest on overflow.
+    static func enqueuePendingPairOp(_ op: PairOp) {
+        var queue = getPendingPairOps()
+        queue.append(op)
+        if queue.count > 10 { queue = Array(queue.suffix(10)) }
+        save(queue, forKey: SharedConstants.pendingPairOpsKey)
+        logger.notice("[Storage] enqueuePendingPairOp: \(op.kind.rawValue, privacy: .public) client=\(op.clientPubkey.prefix(8), privacy: .public) count=\(queue.count)")
+    }
+
+    static func getPendingPairOps() -> [PairOp] {
+        load(forKey: SharedConstants.pendingPairOpsKey) ?? []
+    }
+
+    static func removePendingPairOp(id: String) {
+        var queue = getPendingPairOps()
+        queue.removeAll { $0.id == id }
+        save(queue, forKey: SharedConstants.pendingPairOpsKey)
+    }
+
+    static func bumpPendingPairOpFailCount(id: String) {
+        var queue = getPendingPairOps()
+        guard let idx = queue.firstIndex(where: { $0.id == id }) else { return }
+        queue[idx].failCount += 1
+        save(queue, forKey: SharedConstants.pendingPairOpsKey)
+    }
+
+    static func clearPendingPairOps() {
+        defaults.removeObject(forKey: SharedConstants.pendingPairOpsKey)
+    }
+
     // MARK: - Protected Kinds (Always Ask)
 
     static func getProtectedKinds() -> Set<Int> {

--- a/relay-proxy/clients.js
+++ b/relay-proxy/clients.js
@@ -1,0 +1,69 @@
+const fs = require("node:fs");
+
+function createClientsStorage(filePath) {
+  function isValidPair(p) {
+    return p && typeof p === "object"
+      && typeof p.signerPubkey === "string"
+      && typeof p.clientPubkey === "string"
+      && Array.isArray(p.relayUrls)
+      && typeof p.createdAt === "number"
+      && typeof p.lastSeenAt === "number";
+  }
+
+  function loadAll() {
+    if (!fs.existsSync(filePath)) return [];
+    try {
+      const raw = fs.readFileSync(filePath, "utf8");
+      if (!raw.trim()) return [];
+      const data = JSON.parse(raw);
+      return Array.isArray(data) ? data.filter(isValidPair) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  function saveAll(pairs) {
+    const tmp = filePath + ".tmp";
+    fs.writeFileSync(tmp, JSON.stringify(pairs, null, 2), { mode: 0o644 });
+    fs.renameSync(tmp, filePath);
+  }
+
+  function addPair({ signerPubkey, clientPubkey, relayUrls }) {
+    const all = loadAll();
+    const now = Math.floor(Date.now() / 1000);
+    const idx = all.findIndex((p) => p.signerPubkey === signerPubkey && p.clientPubkey === clientPubkey);
+    if (idx >= 0) {
+      all[idx].relayUrls = relayUrls;
+      all[idx].lastSeenAt = now;
+    } else {
+      all.push({ signerPubkey, clientPubkey, relayUrls, createdAt: now, lastSeenAt: now });
+    }
+    saveAll(all);
+  }
+
+  function removePair({ signerPubkey, clientPubkey }) {
+    const all = loadAll();
+    const idx = all.findIndex((p) => p.signerPubkey === signerPubkey && p.clientPubkey === clientPubkey);
+    if (idx < 0) return null;
+    const [removed] = all.splice(idx, 1);
+    saveAll(all);
+    return removed;
+  }
+
+  function removeBySigner(signerPubkey) {
+    const all = loadAll();
+    const removed = all.filter((p) => p.signerPubkey === signerPubkey);
+    if (removed.length === 0) return [];
+    const remaining = all.filter((p) => p.signerPubkey !== signerPubkey);
+    saveAll(remaining);
+    return removed;
+  }
+
+  function countBySigner(signerPubkey) {
+    return loadAll().filter((p) => p.signerPubkey === signerPubkey).length;
+  }
+
+  return { loadAll, addPair, removePair, removeBySigner, countBySigner };
+}
+
+module.exports = { createClientsStorage };

--- a/relay-proxy/clients.js
+++ b/relay-proxy/clients.js
@@ -63,7 +63,37 @@ function createClientsStorage(filePath) {
     return loadAll().filter((p) => p.signerPubkey === signerPubkey).length;
   }
 
-  return { loadAll, addPair, removePair, removeBySigner, countBySigner };
+  const PRIMARY_RELAY_URL = "wss://relay.powr.build";
+
+  function novelRelayCount(signerPubkey, proposedUrls) {
+    const all = loadAll();
+    const myCurrentRelays = new Set(
+      all.filter((p) => p.signerPubkey === signerPubkey).flatMap((p) => p.relayUrls)
+    );
+    const othersRelays = new Set(
+      all.filter((p) => p.signerPubkey !== signerPubkey).flatMap((p) => p.relayUrls)
+    );
+    const deduped = new Set(proposedUrls);
+    let novel = 0;
+    for (const url of deduped) {
+      if (url === PRIMARY_RELAY_URL) continue;
+      if (myCurrentRelays.has(url)) continue;
+      if (othersRelays.has(url)) continue;
+      novel++;
+    }
+    return novel;
+  }
+
+  function gcStale(maxAgeDays) {
+    const cutoff = Math.floor(Date.now() / 1000) - maxAgeDays * 86400;
+    const all = loadAll();
+    const kept = all.filter((p) => p.createdAt >= cutoff);
+    const removed = all.length - kept.length;
+    if (removed > 0) saveAll(kept);
+    return removed;
+  }
+
+  return { loadAll, addPair, removePair, removeBySigner, countBySigner, novelRelayCount, gcStale };
 }
 
 module.exports = { createClientsStorage };

--- a/relay-proxy/proxy.js
+++ b/relay-proxy/proxy.js
@@ -26,8 +26,11 @@ const PONG_TIMEOUT = 10000; // 10 seconds to respond
 // --- NIP-98 auth + multi-signer storage ---
 const { parseAuthHeader, verifyNip98, sha256Hex } = require("./nip98");
 const { createStorage } = require("./storage");
+const { createClientsStorage } = require("./clients");
 
 const storage = createStorage(TOKEN_FILE);
+const CLIENTS_FILE = "./clients.json";
+const clientsStorage = createClientsStorage(CLIENTS_FILE);
 const migrationResult = storage.migrateIfLegacy();
 if (migrationResult.migrated) {
   console.log(
@@ -377,6 +380,98 @@ const server = http.createServer((req, res) => {
         res.end(JSON.stringify({ ok: true }));
       } catch (e) {
         console.error("[HTTP] /unregister error:", e.message);
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Internal error" }));
+      }
+    });
+  } else if (req.method === "POST" && req.url === "/pair-client") {
+    let body = "";
+    req.on("data", (d) => {
+      body += d;
+      if (body.length > MAX_BODY_SIZE) {
+        req.destroy();
+      }
+    });
+    req.on("end", async () => {
+      try {
+        const authHeader = req.headers["x-clave-auth"];
+        if (!authHeader) {
+          console.log(`[HTTP] /pair-client 401: Missing X-Clave-Auth header`);
+          res.writeHead(401, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "Missing X-Clave-Auth header" }));
+        }
+
+        let authEvent;
+        try {
+          authEvent = parseAuthHeader(authHeader);
+        } catch (e) {
+          console.log(`[HTTP] /pair-client 401: ${e.message}`);
+          res.writeHead(401, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: e.message }));
+        }
+
+        const expectedUrl = `https://proxy.clave.casa/pair-client`;
+        const bodyHash = sha256Hex(Buffer.from(body));
+        const result = await verifyNip98(authEvent, expectedUrl, "POST", bodyHash);
+        if (!result.valid) {
+          console.log(`[HTTP] /pair-client auth failed: ${result.error}`);
+          res.writeHead(401, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: result.error }));
+        }
+
+        let parsed;
+        try {
+          parsed = JSON.parse(body);
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "invalid_body" }));
+        }
+
+        const { client_pubkey, relay_urls } = parsed;
+        if (typeof client_pubkey !== "string" || !/^[0-9a-f]{64}$/.test(client_pubkey)) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "invalid_client_pubkey" }));
+        }
+        if (!Array.isArray(relay_urls) || relay_urls.some((u) => typeof u !== "string")) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "invalid_relay_urls" }));
+        }
+        if (relay_urls.length === 0) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "no_relays" }));
+        }
+        if (relay_urls.length > 10) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "relay_limit_per_pair", limit: 10, requested: relay_urls.length }));
+        }
+
+        const signerPubkey = result.pubkey;
+        const existingCount = clientsStorage.countBySigner(signerPubkey);
+        // Count upsert as 1 if (signer,client) already exists; else +1.
+        const alreadyPaired = clientsStorage.loadAll()
+          .some((p) => p.signerPubkey === signerPubkey && p.clientPubkey === client_pubkey);
+        const projectedCount = alreadyPaired ? existingCount : existingCount + 1;
+        if (projectedCount > 5) {
+          res.writeHead(409, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "pairing_limit", limit: 5, used: existingCount }));
+        }
+
+        const novel = clientsStorage.novelRelayCount(signerPubkey, relay_urls);
+        if (novel > 50) {
+          res.writeHead(409, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "novel_relay_quota", limit: 50 }));
+        }
+
+        clientsStorage.addPair({ signerPubkey, clientPubkey: client_pubkey, relayUrls: relay_urls });
+        // TODO in Task 9: for each relay_urls, call relayPool.addRelay(url)
+        console.log(
+          `[HTTP] Paired client ${client_pubkey.slice(0, 8)}... for signer ${signerPubkey.slice(0, 8)}... with ${relay_urls.length} relays`
+        );
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      } catch (e) {
+        console.error("[HTTP] /pair-client error:", e.message);
         res.writeHead(500, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Internal error" }));
       }

--- a/relay-proxy/proxy.js
+++ b/relay-proxy/proxy.js
@@ -27,10 +27,14 @@ const PONG_TIMEOUT = 10000; // 10 seconds to respond
 const { parseAuthHeader, verifyNip98, sha256Hex } = require("./nip98");
 const { createStorage } = require("./storage");
 const { createClientsStorage } = require("./clients");
+const { createRelayPool } = require("./relayPool");
+
+const PUBLIC_PRIMARY_URL = process.env.PUBLIC_RELAY_URL || "wss://relay.powr.build";
 
 const storage = createStorage(TOKEN_FILE);
 const CLIENTS_FILE = "./clients.json";
 const clientsStorage = createClientsStorage(CLIENTS_FILE);
+let relayPool = null; // initialized in server.listen after all deps are in scope
 const migrationResult = storage.migrateIfLegacy();
 if (migrationResult.migrated) {
   console.log(
@@ -192,66 +196,13 @@ function connectRelay() {
     try {
       const msg = JSON.parse(data.toString());
       if (msg[0] !== "EVENT" || msg[1] !== "clave-watch") return;
-
-      global.lastEventReceivedAt = new Date().toISOString();
-
       const event = msg[2];
-
-      // Extract the signer pubkey from the p-tag on the kind:24133 event
-      const pTag = (event.tags || []).find((t) => t[0] === "p");
-      if (!pTag || !pTag[1]) {
-        console.log(`[Relay] Event ${event.id.slice(0, 8)}... has no p-tag, skipping`);
-        return;
-      }
-      const targetPubkey = pTag[1];
-
-      // Skip responses from the signer themselves (pubkey === targetPubkey means the
-      // signer is p-tagging themselves, which doesn't happen in practice since responses
-      // are p-tagged to the client, but skip for safety)
-      if (event.pubkey === targetPubkey) return;
-
-      const matchingTokens = storage.findByPubkey(targetPubkey);
-      if (matchingTokens.length === 0) {
-        console.log(
-          `[Relay] Event for pubkey ${targetPubkey.slice(0, 8)}... — no registered tokens, skipping`
-        );
-        return;
-      }
-
-      if (alreadySeen(event.id)) {
-        console.log(`[Relay] Duplicate event ${event.id.slice(0, 8)}..., skipping`);
-        return;
-      }
-
-      console.log(
-        `[Relay] Event for pubkey ${targetPubkey.slice(0, 8)}... — pushing to ${matchingTokens.length} device(s)`
-      );
-
-      const pushPayload = {
-        aps: {
-          "mutable-content": 1,
-          "interruption-level": "passive",
-          alert: { title: " ", body: " " },
-        },
-        relay_url: process.env.PUBLIC_RELAY_URL || RELAY_URL,
-        event_id: event.id,
-      };
-
-      for (const entry of matchingTokens) {
-        try {
-          const status = await sendPush(entry.token, pushPayload);
-          if (status === 410) {
-            storage.removeToken({ token: entry.token, pubkey: entry.pubkey });
-            console.log(
-              `[APNs] Removed stale token: ${entry.token.slice(0, 8)}... for ${entry.pubkey.slice(0, 8)}...`
-            );
-          }
-        } catch (e) {
-          console.error(
-            `[APNs] Push failed for ${entry.token.slice(0, 8)}...: ${e.message}`
-          );
-        }
-      }
+      if (!event || event.kind !== 24133) return;
+      await dispatchCaughtEvent({
+        event,
+        sourceUrl: PUBLIC_PRIMARY_URL,
+        classification: "PRIMARY",
+      });
     } catch (e) {
       console.error("[Relay] Message handler error:", e.message);
     }
@@ -463,7 +414,9 @@ const server = http.createServer((req, res) => {
         }
 
         clientsStorage.addPair({ signerPubkey, clientPubkey: client_pubkey, relayUrls: relay_urls });
-        // TODO in Task 9: for each relay_urls, call relayPool.addRelay(url)
+        for (const url of relay_urls) {
+          relayPool.addRelay(url);
+        }
         console.log(
           `[HTTP] Paired client ${client_pubkey.slice(0, 8)}... for signer ${signerPubkey.slice(0, 8)}... with ${relay_urls.length} relays`
         );
@@ -525,7 +478,11 @@ const server = http.createServer((req, res) => {
         const signerPubkey = result.pubkey;
         const removed = clientsStorage.removePair({ signerPubkey, clientPubkey: client_pubkey });
         if (removed) {
-          // TODO in Task 9: for each removed.relayUrls, relayPool.releaseRelay(url)
+          if (Array.isArray(removed.relayUrls)) {
+            for (const url of removed.relayUrls) {
+              relayPool.releaseRelay(url);
+            }
+          }
           console.log(
             `[HTTP] Unpaired client ${client_pubkey.slice(0, 8)}... for signer ${signerPubkey.slice(0, 8)}...`
           );
@@ -563,7 +520,87 @@ const server = http.createServer((req, res) => {
   }
 });
 
+// Shared push pipeline: both the primary-sub handler (inside connectRelay)
+// and the secondary-relay pool route caught kind:24133 events through this.
+// sourceUrl is the relay the event was seen on, classification is PRIMARY|SECONDARY.
+async function dispatchCaughtEvent({ event, sourceUrl, classification }) {
+  const pTag = (event.tags || []).find((t) => t[0] === "p");
+  if (!pTag || !pTag[1]) return;
+  const targetPubkey = pTag[1];
+
+  // Guard against the signer p-tagging themselves (shouldn't happen in practice)
+  if (event.pubkey === targetPubkey) return;
+
+  const matchingTokens = storage.findByPubkey(targetPubkey);
+  if (matchingTokens.length === 0) {
+    console.log(
+      `[${classification}] Event for pubkey ${targetPubkey.slice(0, 8)}... — no registered tokens, skipping`
+    );
+    return;
+  }
+
+  if (alreadySeen(event.id)) return;
+
+  console.log(
+    `[Compliance] source=${sourceUrl} class=${classification} client=${event.pubkey.slice(0, 8)} signer=${targetPubkey.slice(0, 8)} event=${event.id.slice(0, 8)} ts=${new Date().toISOString()}`
+  );
+
+  global.lastEventReceivedAt = new Date().toISOString();
+
+  const pushPayload = {
+    aps: {
+      "mutable-content": 1,
+      "interruption-level": "passive",
+      alert: { title: " ", body: " " },
+    },
+    relay_url: classification === "PRIMARY" ? PUBLIC_PRIMARY_URL : sourceUrl,
+    event_id: event.id,
+  };
+
+  for (const entry of matchingTokens) {
+    try {
+      const status = await sendPush(entry.token, pushPayload);
+      if (status === 410) {
+        storage.removeToken({ token: entry.token, pubkey: entry.pubkey });
+        console.log(
+          `[APNs] Removed stale token: ${entry.token.slice(0, 8)}... for ${entry.pubkey.slice(0, 8)}...`
+        );
+      }
+    } catch (e) {
+      console.error(`[APNs] Push failed for ${entry.token.slice(0, 8)}...: ${e.message}`);
+    }
+  }
+}
+
+function handleSecondaryEvent(relayUrl, event) {
+  dispatchCaughtEvent({ event, sourceUrl: relayUrl, classification: "SECONDARY" }).catch((e) => {
+    console.error(`[Secondary] dispatch error: ${e.message}`);
+  });
+}
+
 server.listen(HTTP_PORT, () => {
   console.log(`[HTTP] Listening on port ${HTTP_PORT}`);
+
+  // Initialize the secondary-relay pool. Signer pubkeys come from the token
+  // storage so new registrations naturally extend the #p filter.
+  relayPool = createRelayPool({
+    signerPubkeysProvider: () => [...new Set(storage.loadTokens().map((t) => t.pubkey))],
+    onEvent: (relayUrl, event) => handleSecondaryEvent(relayUrl, event),
+    logger: console,
+  });
+
+  // Primary sub (ws://localhost:7778) — unchanged behavior, broad filter.
   connectRelay();
+
+  // Boot-time restoration: open secondary subs for every paired relay URL.
+  // Deduplicated by relayPool's ref counting (union across pairings).
+  const allPairs = clientsStorage.loadAll();
+  const bootRelays = new Set(allPairs.flatMap((p) => p.relayUrls));
+  for (const url of bootRelays) {
+    if (url === PUBLIC_PRIMARY_URL) continue; // skip primary
+    relayPool.addRelay(url);
+  }
+  if (bootRelays.size > 0) {
+    console.log(`[Boot] Restored ${bootRelays.size} secondary relay subs from clients.json`);
+  }
 });

--- a/relay-proxy/proxy.js
+++ b/relay-proxy/proxy.js
@@ -397,6 +397,22 @@ const server = http.createServer((req, res) => {
           res.writeHead(400, { "Content-Type": "application/json" });
           return res.end(JSON.stringify({ error: "relay_limit_per_pair", limit: 10, requested: relay_urls.length }));
         }
+        // Validate each URL is parseable and ws/wss before passing to relayPool.addRelay —
+        // the `ws` constructor throws synchronously on malformed input, which would leave
+        // clients.json and the pool out of sync if we didn't pre-validate.
+        for (const url of relay_urls) {
+          let parsed;
+          try {
+            parsed = new URL(url);
+          } catch {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            return res.end(JSON.stringify({ error: "invalid_relay_url", url }));
+          }
+          if (parsed.protocol !== "wss:" && parsed.protocol !== "ws:") {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            return res.end(JSON.stringify({ error: "invalid_relay_url", url }));
+          }
+        }
 
         const signerPubkey = result.pubkey;
         const existingCount = clientsStorage.countBySigner(signerPubkey);
@@ -580,22 +596,19 @@ function handleSecondaryEvent(relayUrl, event) {
   });
 }
 
-server.listen(HTTP_PORT, () => {
-  console.log(`[HTTP] Listening on port ${HTTP_PORT}`);
+// Initialize the secondary-relay pool at module scope BEFORE server.listen so
+// incoming requests to /pair-client (which arrive the moment listen() returns)
+// never race with pool init. The pool has no network cost until addRelay is
+// called, so safe to create eagerly.
+relayPool = createRelayPool({
+  signerPubkeysProvider: () => [...new Set(storage.loadTokens().map((t) => t.pubkey))],
+  onEvent: (relayUrl, event) => handleSecondaryEvent(relayUrl, event),
+  logger: console,
+});
 
-  // Initialize the secondary-relay pool. Signer pubkeys come from the token
-  // storage so new registrations naturally extend the #p filter.
-  relayPool = createRelayPool({
-    signerPubkeysProvider: () => [...new Set(storage.loadTokens().map((t) => t.pubkey))],
-    onEvent: (relayUrl, event) => handleSecondaryEvent(relayUrl, event),
-    logger: console,
-  });
-
-  // Primary sub (ws://localhost:7778) — unchanged behavior, broad filter.
-  connectRelay();
-
-  // Boot-time restoration: open secondary subs for every paired relay URL.
-  // Deduplicated by relayPool's ref counting (union across pairings).
+// Boot-time restoration: open secondary subs for every paired relay URL.
+// Deduplicated by relayPool's ref counting (union across pairings).
+{
   const allPairs = clientsStorage.loadAll();
   const bootRelays = new Set(allPairs.flatMap((p) => p.relayUrls));
   for (const url of bootRelays) {
@@ -605,4 +618,10 @@ server.listen(HTTP_PORT, () => {
   if (bootRelays.size > 0) {
     console.log(`[Boot] Restored ${bootRelays.size} secondary relay subs from clients.json`);
   }
+}
+
+server.listen(HTTP_PORT, () => {
+  console.log(`[HTTP] Listening on port ${HTTP_PORT}`);
+  // Primary sub (ws://localhost:7778) — unchanged behavior, broad filter.
+  connectRelay();
 });

--- a/relay-proxy/proxy.js
+++ b/relay-proxy/proxy.js
@@ -266,6 +266,7 @@ const server = http.createServer((req, res) => {
         }
 
         storage.upsertToken({ token, pubkey: result.pubkey });
+        if (relayPool) relayPool.refreshFilter();
         console.log(
           `[HTTP] Registered ${token.slice(0, 8)}... for pubkey ${result.pubkey.slice(0, 8)}...`
         );
@@ -323,6 +324,7 @@ const server = http.createServer((req, res) => {
         }
 
         storage.removeToken({ token, pubkey: result.pubkey });
+        if (relayPool) relayPool.refreshFilter();
         console.log(
           `[HTTP] Unregistered ${token.slice(0, 8)}... for pubkey ${result.pubkey.slice(0, 8)}...`
         );

--- a/relay-proxy/proxy.js
+++ b/relay-proxy/proxy.js
@@ -476,6 +476,73 @@ const server = http.createServer((req, res) => {
         res.end(JSON.stringify({ error: "Internal error" }));
       }
     });
+  } else if (req.method === "POST" && req.url === "/unpair-client") {
+    let body = "";
+    req.on("data", (d) => {
+      body += d;
+      if (body.length > MAX_BODY_SIZE) {
+        req.destroy();
+      }
+    });
+    req.on("end", async () => {
+      try {
+        const authHeader = req.headers["x-clave-auth"];
+        if (!authHeader) {
+          res.writeHead(401, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "Missing X-Clave-Auth header" }));
+        }
+
+        let authEvent;
+        try {
+          authEvent = parseAuthHeader(authHeader);
+        } catch (e) {
+          res.writeHead(401, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: e.message }));
+        }
+
+        const expectedUrl = `https://proxy.clave.casa/unpair-client`;
+        const bodyHash = sha256Hex(Buffer.from(body));
+        const result = await verifyNip98(authEvent, expectedUrl, "POST", bodyHash);
+        if (!result.valid) {
+          res.writeHead(401, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: result.error }));
+        }
+
+        let parsed;
+        try {
+          parsed = JSON.parse(body);
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "invalid_body" }));
+        }
+
+        const { client_pubkey } = parsed;
+        if (typeof client_pubkey !== "string" || !/^[0-9a-f]{64}$/.test(client_pubkey)) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "invalid_client_pubkey" }));
+        }
+
+        const signerPubkey = result.pubkey;
+        const removed = clientsStorage.removePair({ signerPubkey, clientPubkey: client_pubkey });
+        if (removed) {
+          // TODO in Task 9: for each removed.relayUrls, relayPool.releaseRelay(url)
+          console.log(
+            `[HTTP] Unpaired client ${client_pubkey.slice(0, 8)}... for signer ${signerPubkey.slice(0, 8)}...`
+          );
+        } else {
+          console.log(
+            `[HTTP] /unpair-client: no pair found for signer ${signerPubkey.slice(0, 8)}... / client ${client_pubkey.slice(0, 8)}...`
+          );
+        }
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      } catch (e) {
+        console.error("[HTTP] /unpair-client error:", e.message);
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Internal error" }));
+      }
+    });
   } else if (req.method === "GET" && req.url === "/health") {
     const allTokens = storage.loadTokens();
     const pubkeys = new Set(allTokens.map((t) => t.pubkey));

--- a/relay-proxy/relayPool.js
+++ b/relay-proxy/relayPool.js
@@ -8,8 +8,9 @@ function createRelayPool({
   signerPubkeysProvider = () => [],
   onEvent = () => {},
   logger = console,
+  reconnectInitialMs = 1000,
+  reconnectMaxMs = 600_000, // 10 min
 } = {}) {
-  // URL → { ws, refCount, state, url }
   const pool = new Map();
 
   function narrowFilter() {
@@ -29,14 +30,26 @@ function createRelayPool({
     if (!entry.ws || entry.ws.readyState !== WebSocket.OPEN) return;
     try {
       entry.ws.send(JSON.stringify(["CLOSE", SUB_ID]));
-    } catch (e) {
-      // best-effort
-    }
+    } catch {}
+  }
+
+  function scheduleReconnect(entry) {
+    if (entry.refCount <= 0) return; // released; don't reconnect
+    if (entry.reconnectTimer) return; // already scheduled
+    const delay = Math.min(entry.backoffMs, reconnectMaxMs);
+    logger.log(`[RelayPool] ${entry.url} reconnecting in ${delay}ms (failures=${entry.failures})`);
+    entry.reconnectTimer = setTimeout(() => {
+      entry.reconnectTimer = null;
+      if (entry.refCount <= 0) return;
+      entry.backoffMs = Math.min(entry.backoffMs * 2, reconnectMaxMs);
+      openSocket(entry);
+    }, delay);
   }
 
   function attachHandlers(entry) {
     entry.ws.on("open", () => {
       entry.state = "ready";
+      entry.backoffMs = reconnectInitialMs; // reset backoff on success
       logger.log(`[RelayPool] ${entry.url} connected`);
       sendReq(entry);
     });
@@ -60,6 +73,8 @@ function createRelayPool({
 
     entry.ws.on("close", () => {
       entry.state = "closed";
+      entry.failures++;
+      scheduleReconnect(entry);
     });
 
     entry.ws.on("error", (err) => {
@@ -67,8 +82,14 @@ function createRelayPool({
     });
   }
 
+  function openSocket(entry) {
+    entry.ws = createSocket(entry.url);
+    entry.state = "connecting";
+    attachHandlers(entry);
+  }
+
   function addRelay(url) {
-    if (url === PRIMARY_RELAY_URL) return; // covered by top-level primary sub in proxy.js
+    if (url === PRIMARY_RELAY_URL) return;
     const existing = pool.get(url);
     if (existing) {
       existing.refCount++;
@@ -76,12 +97,15 @@ function createRelayPool({
     }
     const entry = {
       url,
-      ws: createSocket(url),
+      ws: null,
       refCount: 1,
       state: "connecting",
+      backoffMs: reconnectInitialMs,
+      failures: 0,
+      reconnectTimer: null,
     };
     pool.set(url, entry);
-    attachHandlers(entry);
+    openSocket(entry);
   }
 
   function releaseRelay(url) {
@@ -89,22 +113,13 @@ function createRelayPool({
     if (!entry) return;
     entry.refCount--;
     if (entry.refCount <= 0) {
+      if (entry.reconnectTimer) clearTimeout(entry.reconnectTimer);
       sendClose(entry);
       try {
-        entry.ws.close();
+        entry.ws && entry.ws.close();
       } catch {}
       pool.delete(url);
     }
-  }
-
-  function getState(url) {
-    const entry = pool.get(url);
-    if (!entry) return null;
-    return { url: entry.url, refCount: entry.refCount, state: entry.state };
-  }
-
-  function listUrls() {
-    return Array.from(pool.keys());
   }
 
   function refreshFilter() {
@@ -115,7 +130,30 @@ function createRelayPool({
     }
   }
 
-  return { addRelay, releaseRelay, refreshFilter, getState, listUrls };
+  function getState(url) {
+    const entry = pool.get(url);
+    if (!entry) return null;
+    return {
+      url: entry.url,
+      refCount: entry.refCount,
+      state: entry.state,
+      failures: entry.failures,
+    };
+  }
+
+  function listUrls() {
+    return Array.from(pool.keys());
+  }
+
+  function shutdown() {
+    for (const entry of pool.values()) {
+      if (entry.reconnectTimer) clearTimeout(entry.reconnectTimer);
+      try { entry.ws && entry.ws.close(); } catch {}
+    }
+    pool.clear();
+  }
+
+  return { addRelay, releaseRelay, refreshFilter, getState, listUrls, shutdown };
 }
 
 module.exports = { createRelayPool };

--- a/relay-proxy/relayPool.js
+++ b/relay-proxy/relayPool.js
@@ -3,6 +3,12 @@ const WebSocket = require("ws");
 const SUB_ID = "clave-watch";
 const PRIMARY_RELAY_URL = "wss://relay.powr.build";
 
+// Same heartbeat settings as the primary sub in proxy.js (connectRelay).
+// NAT/firewall can silently drop idle TCP; without ping/pong the pool would
+// happily sit on a zombie socket and miss events indefinitely.
+const PING_INTERVAL_MS = 30_000;
+const PONG_TIMEOUT_MS = 10_000;
+
 function createRelayPool({
   createSocket = (url) => new WebSocket(url),
   signerPubkeysProvider = () => [],
@@ -10,6 +16,8 @@ function createRelayPool({
   logger = console,
   reconnectInitialMs = 1000,
   reconnectMaxMs = 600_000, // 10 min
+  pingIntervalMs = PING_INTERVAL_MS,
+  pongTimeoutMs = PONG_TIMEOUT_MS,
 } = {}) {
   const pool = new Map();
 
@@ -33,6 +41,33 @@ function createRelayPool({
     } catch {}
   }
 
+  function startHeartbeat(entry) {
+    stopHeartbeat(entry);
+    entry.pingTimer = setInterval(() => {
+      if (!entry.ws || entry.ws.readyState !== WebSocket.OPEN) return;
+      try {
+        entry.ws.ping();
+      } catch {}
+      entry.pongTimer = setTimeout(() => {
+        logger.error(`[RelayPool] ${entry.url} pong timeout — terminating`);
+        try {
+          entry.ws.terminate();
+        } catch {}
+      }, pongTimeoutMs);
+    }, pingIntervalMs);
+  }
+
+  function stopHeartbeat(entry) {
+    if (entry.pingTimer) {
+      clearInterval(entry.pingTimer);
+      entry.pingTimer = null;
+    }
+    if (entry.pongTimer) {
+      clearTimeout(entry.pongTimer);
+      entry.pongTimer = null;
+    }
+  }
+
   function scheduleReconnect(entry) {
     if (entry.refCount <= 0) return; // released; don't reconnect
     if (entry.reconnectTimer) return; // already scheduled
@@ -52,6 +87,7 @@ function createRelayPool({
       entry.backoffMs = reconnectInitialMs; // reset backoff on success
       logger.log(`[RelayPool] ${entry.url} connected`);
       sendReq(entry);
+      startHeartbeat(entry);
     });
 
     entry.ws.on("message", (data) => {
@@ -71,9 +107,17 @@ function createRelayPool({
       }
     });
 
+    entry.ws.on("pong", () => {
+      if (entry.pongTimer) {
+        clearTimeout(entry.pongTimer);
+        entry.pongTimer = null;
+      }
+    });
+
     entry.ws.on("close", () => {
       entry.state = "closed";
       entry.failures++;
+      stopHeartbeat(entry);
       scheduleReconnect(entry);
     });
 
@@ -103,6 +147,8 @@ function createRelayPool({
       backoffMs: reconnectInitialMs,
       failures: 0,
       reconnectTimer: null,
+      pingTimer: null,
+      pongTimer: null,
     };
     pool.set(url, entry);
     openSocket(entry);
@@ -114,6 +160,7 @@ function createRelayPool({
     entry.refCount--;
     if (entry.refCount <= 0) {
       if (entry.reconnectTimer) clearTimeout(entry.reconnectTimer);
+      stopHeartbeat(entry);
       sendClose(entry);
       try {
         entry.ws && entry.ws.close();
@@ -148,6 +195,7 @@ function createRelayPool({
   function shutdown() {
     for (const entry of pool.values()) {
       if (entry.reconnectTimer) clearTimeout(entry.reconnectTimer);
+      stopHeartbeat(entry);
       try { entry.ws && entry.ws.close(); } catch {}
     }
     pool.clear();

--- a/relay-proxy/relayPool.js
+++ b/relay-proxy/relayPool.js
@@ -1,0 +1,113 @@
+const WebSocket = require("ws");
+
+const SUB_ID = "clave-watch";
+const PRIMARY_RELAY_URL = "wss://relay.powr.build";
+
+function createRelayPool({
+  createSocket = (url) => new WebSocket(url),
+  signerPubkeysProvider = () => [],
+  onEvent = () => {},
+  logger = console,
+} = {}) {
+  // URL → { ws, refCount, state, url }
+  const pool = new Map();
+
+  function narrowFilter() {
+    return {
+      kinds: [24133],
+      "#p": signerPubkeysProvider(),
+      since: Math.floor(Date.now() / 1000),
+    };
+  }
+
+  function sendReq(entry) {
+    if (!entry.ws || entry.ws.readyState !== WebSocket.OPEN) return;
+    entry.ws.send(JSON.stringify(["REQ", SUB_ID, narrowFilter()]));
+  }
+
+  function sendClose(entry) {
+    if (!entry.ws || entry.ws.readyState !== WebSocket.OPEN) return;
+    try {
+      entry.ws.send(JSON.stringify(["CLOSE", SUB_ID]));
+    } catch (e) {
+      // best-effort
+    }
+  }
+
+  function attachHandlers(entry) {
+    entry.ws.on("open", () => {
+      entry.state = "ready";
+      logger.log(`[RelayPool] ${entry.url} connected`);
+      sendReq(entry);
+    });
+
+    entry.ws.on("message", (data) => {
+      let msg;
+      try {
+        msg = JSON.parse(data.toString());
+      } catch {
+        return;
+      }
+      if (!Array.isArray(msg) || msg[0] !== "EVENT" || msg[1] !== SUB_ID) return;
+      const event = msg[2];
+      if (!event || event.kind !== 24133) return;
+      try {
+        onEvent(entry.url, event);
+      } catch (e) {
+        logger.error(`[RelayPool] onEvent threw for ${entry.url}: ${e.message}`);
+      }
+    });
+
+    entry.ws.on("close", () => {
+      entry.state = "closed";
+    });
+
+    entry.ws.on("error", (err) => {
+      logger.error(`[RelayPool] ${entry.url} error: ${err.message}`);
+    });
+  }
+
+  function addRelay(url) {
+    if (url === PRIMARY_RELAY_URL) return; // covered by top-level primary sub in proxy.js
+    const existing = pool.get(url);
+    if (existing) {
+      existing.refCount++;
+      return;
+    }
+    const entry = {
+      url,
+      ws: createSocket(url),
+      refCount: 1,
+      state: "connecting",
+    };
+    pool.set(url, entry);
+    attachHandlers(entry);
+  }
+
+  function releaseRelay(url) {
+    const entry = pool.get(url);
+    if (!entry) return;
+    entry.refCount--;
+    if (entry.refCount <= 0) {
+      sendClose(entry);
+      try {
+        entry.ws.close();
+      } catch {}
+      pool.delete(url);
+    }
+  }
+
+  function getState(url) {
+    const entry = pool.get(url);
+    if (!entry) return null;
+    return { url: entry.url, refCount: entry.refCount, state: entry.state };
+  }
+
+  function listUrls() {
+    return Array.from(pool.keys());
+  }
+
+  return { addRelay, releaseRelay, getState, listUrls };
+}
+
+module.exports = { createRelayPool };

--- a/relay-proxy/relayPool.js
+++ b/relay-proxy/relayPool.js
@@ -107,7 +107,15 @@ function createRelayPool({
     return Array.from(pool.keys());
   }
 
-  return { addRelay, releaseRelay, getState, listUrls };
+  function refreshFilter() {
+    for (const entry of pool.values()) {
+      if (!entry.ws || entry.ws.readyState !== WebSocket.OPEN) continue;
+      sendClose(entry);
+      sendReq(entry);
+    }
+  }
+
+  return { addRelay, releaseRelay, refreshFilter, getState, listUrls };
 }
 
 module.exports = { createRelayPool };

--- a/relay-proxy/test/clients.test.js
+++ b/relay-proxy/test/clients.test.js
@@ -133,3 +133,74 @@ test("atomic write: temp file is cleaned up after rename", () => {
   assert.ok(!fs.existsSync(file + ".tmp"), "temp file should not remain after write");
   assert.ok(fs.existsSync(file), "target file should exist");
 });
+
+test("novelRelayCount returns 0 when all URLs are already in user's own pool", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c1", relayUrls: ["wss://a", "wss://b"] });
+  assert.equal(storage.novelRelayCount("s1", ["wss://a", "wss://b"]), 0);
+});
+
+test("novelRelayCount counts only URLs not in any pairing", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c1", relayUrls: ["wss://a"] });
+  // wss://b is novel (not in any pool yet); wss://a is not (already in s1's pool)
+  assert.equal(storage.novelRelayCount("s1", ["wss://a", "wss://b"]), 1);
+});
+
+test("novelRelayCount excludes relay.powr.build", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  // relay.powr.build is always covered by primary sub; never counts as novel
+  assert.equal(storage.novelRelayCount("s1", ["wss://relay.powr.build"]), 0);
+});
+
+test("novelRelayCount treats URLs already used by other users as non-novel", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  storage.addPair({ signerPubkey: "s2", clientPubkey: "c1", relayUrls: ["wss://shared"] });
+  // s1 hasn't used wss://shared before, but s2 has — pool already covers it → not novel
+  assert.equal(storage.novelRelayCount("s1", ["wss://shared"]), 0);
+});
+
+test("novelRelayCount deduplicates proposedUrls", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  assert.equal(storage.novelRelayCount("s1", ["wss://a", "wss://a", "wss://a"]), 1);
+});
+
+test("gcStale removes pairs older than maxAgeDays and returns count", async () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c1", relayUrls: [] });
+  // Manually rewrite the file so one entry is "old" (createdAt in the past)
+  const all = storage.loadAll();
+  all.push({
+    signerPubkey: "s2",
+    clientPubkey: "c1",
+    relayUrls: [],
+    createdAt: Math.floor(Date.now() / 1000) - (100 * 86400), // 100 days ago
+    lastSeenAt: Math.floor(Date.now() / 1000),
+  });
+  fs.writeFileSync(file, JSON.stringify(all, null, 2));
+  const removed = storage.gcStale(90);
+  assert.equal(removed, 1);
+  const remaining = storage.loadAll();
+  assert.equal(remaining.length, 1);
+  assert.equal(remaining[0].signerPubkey, "s1");
+});
+
+test("gcStale returns 0 when nothing is stale", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c1", relayUrls: [] });
+  assert.equal(storage.gcStale(90), 0);
+});

--- a/relay-proxy/test/clients.test.js
+++ b/relay-proxy/test/clients.test.js
@@ -1,0 +1,135 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+
+function tmpFile() {
+  return path.join(os.tmpdir(), `clave-clients-test-${Date.now()}-${Math.random()}.json`);
+}
+
+test("loadAll returns empty array when file doesn't exist", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  assert.deepEqual(storage.loadAll(), []);
+});
+
+test("addPair adds a new entry with timestamps", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c1", relayUrls: ["wss://a", "wss://b"] });
+  const all = storage.loadAll();
+  assert.equal(all.length, 1);
+  assert.equal(all[0].signerPubkey, "s1");
+  assert.equal(all[0].clientPubkey, "c1");
+  assert.deepEqual(all[0].relayUrls, ["wss://a", "wss://b"]);
+  assert.ok(typeof all[0].createdAt === "number");
+  assert.ok(typeof all[0].lastSeenAt === "number");
+});
+
+test("addPair is idempotent — upserts relayUrls + lastSeenAt on (signer, client) match", async () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c1", relayUrls: ["wss://a"] });
+  const firstCreated = storage.loadAll()[0].createdAt;
+  await new Promise((r) => setTimeout(r, 1100));
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c1", relayUrls: ["wss://x", "wss://y"] });
+  const all = storage.loadAll();
+  assert.equal(all.length, 1);
+  assert.deepEqual(all[0].relayUrls, ["wss://x", "wss://y"]);
+  assert.equal(all[0].createdAt, firstCreated, "createdAt is preserved on upsert");
+  assert.ok(all[0].lastSeenAt > firstCreated, "lastSeenAt updates on upsert");
+});
+
+test("addPair with different clientPubkey creates separate entry", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c1", relayUrls: ["wss://a"] });
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c2", relayUrls: ["wss://b"] });
+  assert.equal(storage.loadAll().length, 2);
+});
+
+test("removePair removes matching entry and returns it", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c1", relayUrls: ["wss://a"] });
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c2", relayUrls: ["wss://b"] });
+  const removed = storage.removePair({ signerPubkey: "s1", clientPubkey: "c1" });
+  assert.equal(removed.clientPubkey, "c1");
+  const remaining = storage.loadAll();
+  assert.equal(remaining.length, 1);
+  assert.equal(remaining[0].clientPubkey, "c2");
+});
+
+test("removePair returns null when no match", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  const result = storage.removePair({ signerPubkey: "nope", clientPubkey: "nope" });
+  assert.equal(result, null);
+});
+
+test("removeBySigner removes all entries for a signer and returns them", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c1", relayUrls: ["wss://a"] });
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c2", relayUrls: ["wss://b"] });
+  storage.addPair({ signerPubkey: "s2", clientPubkey: "c1", relayUrls: ["wss://c"] });
+  const removed = storage.removeBySigner("s1");
+  assert.equal(removed.length, 2);
+  const remaining = storage.loadAll();
+  assert.equal(remaining.length, 1);
+  assert.equal(remaining[0].signerPubkey, "s2");
+});
+
+test("countBySigner returns 0 for unknown signer", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  assert.equal(storage.countBySigner("nope"), 0);
+});
+
+test("countBySigner returns correct count per signer", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c1", relayUrls: [] });
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c2", relayUrls: [] });
+  storage.addPair({ signerPubkey: "s2", clientPubkey: "c1", relayUrls: [] });
+  assert.equal(storage.countBySigner("s1"), 2);
+  assert.equal(storage.countBySigner("s2"), 1);
+});
+
+test("loadAll ignores malformed JSON", () => {
+  const file = tmpFile();
+  fs.writeFileSync(file, "not json {{{");
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  assert.deepEqual(storage.loadAll(), []);
+});
+
+test("loadAll filters out entries missing required fields", () => {
+  const file = tmpFile();
+  fs.writeFileSync(file, JSON.stringify([
+    { signerPubkey: "s1", clientPubkey: "c1", relayUrls: [], createdAt: 1, lastSeenAt: 1 },
+    { signerPubkey: "incomplete" },
+  ]));
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  assert.equal(storage.loadAll().length, 1);
+});
+
+test("atomic write: temp file is cleaned up after rename", () => {
+  const file = tmpFile();
+  const { createClientsStorage } = require("../clients");
+  const storage = createClientsStorage(file);
+  storage.addPair({ signerPubkey: "s1", clientPubkey: "c1", relayUrls: [] });
+  assert.ok(!fs.existsSync(file + ".tmp"), "temp file should not remain after write");
+  assert.ok(fs.existsSync(file), "target file should exist");
+});

--- a/relay-proxy/test/relayPool.test.js
+++ b/relay-proxy/test/relayPool.test.js
@@ -152,3 +152,47 @@ test("message handler ignores messages with wrong subscription id", () => {
   factory.sockets[0].emit("message", Buffer.from(JSON.stringify(["EVENT", "other-sub", event])));
   assert.equal(received.length, 0);
 });
+
+test("refreshFilter sends CLOSE + new REQ on every open WS", () => {
+  const factory = makeFactory();
+  let signers = ["s1"];
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => signers,
+  });
+  pool.addRelay("wss://a");
+  pool.addRelay("wss://b");
+  factory.sockets[0]._openFromServer();
+  factory.sockets[1]._openFromServer();
+  // Clear the initial REQs from tracking
+  factory.sockets[0].sent.length = 0;
+  factory.sockets[1].sent.length = 0;
+
+  signers = ["s1", "s2"];
+  pool.refreshFilter();
+
+  for (const ws of factory.sockets) {
+    assert.equal(ws.sent.length, 2, "expect CLOSE then REQ on each WS");
+    const [closeVerb, closeSubId] = JSON.parse(ws.sent[0]);
+    assert.equal(closeVerb, "CLOSE");
+    assert.equal(closeSubId, "clave-watch");
+    const [reqVerb, reqSubId, filter] = JSON.parse(ws.sent[1]);
+    assert.equal(reqVerb, "REQ");
+    assert.equal(reqSubId, "clave-watch");
+    assert.deepEqual(filter["#p"], ["s1", "s2"]);
+  }
+});
+
+test("refreshFilter is a no-op for WSs not yet open", () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+  });
+  pool.addRelay("wss://a");
+  // Do NOT open the socket
+  pool.refreshFilter();
+  assert.equal(factory.sockets[0].sent.length, 0, "no messages sent to un-opened sockets");
+});

--- a/relay-proxy/test/relayPool.test.js
+++ b/relay-proxy/test/relayPool.test.js
@@ -7,14 +7,17 @@ function makeFakeSocket() {
   const ws = new EventEmitter();
   ws.readyState = 0; // CONNECTING
   ws.sent = [];
+  ws.pingCount = 0;
+  ws.terminated = false;
   ws.send = (msg) => ws.sent.push(msg);
-  ws.ping = () => {};
+  ws.ping = () => { ws.pingCount++; };
   ws.close = () => {
     ws.readyState = 3; // CLOSED
     ws.emit("close");
   };
   ws.terminate = () => {
     ws.readyState = 3;
+    ws.terminated = true;
     ws.emit("close");
   };
   // Helper for tests — simulate the server side opening the socket
@@ -249,4 +252,76 @@ test("no reconnect after releaseRelay drops refcount to 0", async () => {
   pool.releaseRelay("wss://a");
   await new Promise((r) => setTimeout(r, 30));
   assert.equal(factory.sockets.length, 1, "should NOT create replacement after release");
+});
+
+test("heartbeat pings open socket on interval", async () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    pingIntervalMs: 20,
+    pongTimeoutMs: 50,
+  });
+  pool.addRelay("wss://a");
+  factory.sockets[0]._openFromServer();
+  await new Promise((r) => setTimeout(r, 50));
+  assert.ok(factory.sockets[0].pingCount >= 2, `expected ≥2 pings, got ${factory.sockets[0].pingCount}`);
+  pool.shutdown();
+});
+
+test("pong-timeout triggers ws.terminate()", async () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    pingIntervalMs: 10,
+    pongTimeoutMs: 20,
+  });
+  pool.addRelay("wss://a");
+  factory.sockets[0]._openFromServer();
+  // Do NOT emit 'pong' — simulate silent zombie socket
+  await new Promise((r) => setTimeout(r, 50));
+  assert.ok(factory.sockets[0].terminated, "silent socket should have been terminated");
+  pool.shutdown();
+});
+
+test("pong reply cancels pong-timeout", async () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    pingIntervalMs: 10,
+    pongTimeoutMs: 30,
+  });
+  pool.addRelay("wss://a");
+  factory.sockets[0]._openFromServer();
+  // Keep replying to every ping with a pong
+  const pongInterval = setInterval(() => {
+    factory.sockets[0].emit("pong");
+  }, 5);
+  await new Promise((r) => setTimeout(r, 50));
+  clearInterval(pongInterval);
+  assert.ok(!factory.sockets[0].terminated, "responsive socket should NOT be terminated");
+  pool.shutdown();
+});
+
+test("heartbeat stops on release", async () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    pingIntervalMs: 10,
+    pongTimeoutMs: 20,
+  });
+  pool.addRelay("wss://a");
+  factory.sockets[0]._openFromServer();
+  await new Promise((r) => setTimeout(r, 15));
+  const pingCountBeforeRelease = factory.sockets[0].pingCount;
+  pool.releaseRelay("wss://a");
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(factory.sockets[0].pingCount, pingCountBeforeRelease, "no further pings after release");
 });

--- a/relay-proxy/test/relayPool.test.js
+++ b/relay-proxy/test/relayPool.test.js
@@ -196,3 +196,57 @@ test("refreshFilter is a no-op for WSs not yet open", () => {
   pool.refreshFilter();
   assert.equal(factory.sockets[0].sent.length, 0, "no messages sent to un-opened sockets");
 });
+
+test("on WS close, opens a new WS after backoff (still ref'd)", async () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    reconnectInitialMs: 10,
+    reconnectMaxMs: 50,
+  });
+  pool.addRelay("wss://a");
+  factory.sockets[0]._openFromServer();
+  // Simulate server-side disconnect
+  factory.sockets[0].emit("close");
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(factory.sockets.length, 2, "should have created a replacement WS");
+  assert.equal(factory.sockets[1]._url, "wss://a");
+});
+
+test("reconnect backoff grows on repeated failures, capped at max", async () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    reconnectInitialMs: 10,
+    reconnectMaxMs: 40,
+  });
+  pool.addRelay("wss://a");
+  // Three sequential failures — each close before open
+  factory.sockets[0].emit("close"); // backoff 10ms → new WS
+  await new Promise((r) => setTimeout(r, 20));
+  factory.sockets[1].emit("close"); // backoff 20ms → new WS
+  await new Promise((r) => setTimeout(r, 30));
+  factory.sockets[2].emit("close"); // backoff 40ms (capped) → new WS
+  await new Promise((r) => setTimeout(r, 50));
+  assert.ok(factory.sockets.length >= 4, `expected ≥ 4 sockets, got ${factory.sockets.length}`);
+});
+
+test("no reconnect after releaseRelay drops refcount to 0", async () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    reconnectInitialMs: 10,
+    reconnectMaxMs: 50,
+  });
+  pool.addRelay("wss://a");
+  factory.sockets[0]._openFromServer();
+  pool.releaseRelay("wss://a");
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(factory.sockets.length, 1, "should NOT create replacement after release");
+});

--- a/relay-proxy/test/relayPool.test.js
+++ b/relay-proxy/test/relayPool.test.js
@@ -1,0 +1,154 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+
+// Minimal in-process fake WebSocket — mimics the subset of `ws` API the pool uses.
+function makeFakeSocket() {
+  const ws = new EventEmitter();
+  ws.readyState = 0; // CONNECTING
+  ws.sent = [];
+  ws.send = (msg) => ws.sent.push(msg);
+  ws.ping = () => {};
+  ws.close = () => {
+    ws.readyState = 3; // CLOSED
+    ws.emit("close");
+  };
+  ws.terminate = () => {
+    ws.readyState = 3;
+    ws.emit("close");
+  };
+  // Helper for tests — simulate the server side opening the socket
+  ws._openFromServer = () => {
+    ws.readyState = 1; // OPEN
+    ws.emit("open");
+  };
+  return ws;
+}
+
+function makeFactory() {
+  const sockets = [];
+  const factory = (url) => {
+    const ws = makeFakeSocket();
+    ws._url = url;
+    sockets.push(ws);
+    return ws;
+  };
+  factory.sockets = sockets;
+  return factory;
+}
+
+test("addRelay opens one WebSocket on first ref", () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({ createSocket: factory, signerPubkeysProvider: () => ["s1"] });
+  pool.addRelay("wss://a");
+  assert.equal(factory.sockets.length, 1);
+  assert.equal(factory.sockets[0]._url, "wss://a");
+});
+
+test("addRelay on same URL bumps refcount without opening another WS", () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({ createSocket: factory, signerPubkeysProvider: () => ["s1"] });
+  pool.addRelay("wss://a");
+  pool.addRelay("wss://a");
+  assert.equal(factory.sockets.length, 1);
+  assert.equal(pool.getState("wss://a").refCount, 2);
+});
+
+test("releaseRelay decrements refcount; does not close until refs hit 0", () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({ createSocket: factory, signerPubkeysProvider: () => ["s1"] });
+  pool.addRelay("wss://a");
+  pool.addRelay("wss://a");
+  pool.releaseRelay("wss://a");
+  assert.equal(pool.getState("wss://a").refCount, 1);
+  assert.notEqual(factory.sockets[0].readyState, 3, "should still be open");
+});
+
+test("releaseRelay closes WS when refcount reaches 0", () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({ createSocket: factory, signerPubkeysProvider: () => ["s1"] });
+  pool.addRelay("wss://a");
+  pool.releaseRelay("wss://a");
+  assert.equal(factory.sockets[0].readyState, 3, "WS should be closed");
+  assert.equal(pool.getState("wss://a"), null, "entry should be removed");
+});
+
+test("releaseRelay on unknown URL is a no-op", () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({ createSocket: factory, signerPubkeysProvider: () => ["s1"] });
+  pool.releaseRelay("wss://never-added");
+  assert.equal(factory.sockets.length, 0);
+});
+
+test("on WS open, sends narrow REQ with kinds:[24133] + #p filter", () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1", "s2"],
+  });
+  pool.addRelay("wss://a");
+  factory.sockets[0]._openFromServer();
+  assert.equal(factory.sockets[0].sent.length, 1);
+  const [verb, subId, filter] = JSON.parse(factory.sockets[0].sent[0]);
+  assert.equal(verb, "REQ");
+  assert.equal(subId, "clave-watch");
+  assert.deepEqual(filter.kinds, [24133]);
+  assert.deepEqual(filter["#p"], ["s1", "s2"]);
+  assert.ok(typeof filter.since === "number");
+});
+
+test("message handler invokes onEvent(url, event) for matching kind:24133", () => {
+  const factory = makeFactory();
+  const received = [];
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    onEvent: (url, evt) => received.push({ url, evt }),
+  });
+  pool.addRelay("wss://a");
+  factory.sockets[0]._openFromServer();
+  const event = { id: "e1", kind: 24133, pubkey: "c1", tags: [["p", "s1"]], content: "..." };
+  factory.sockets[0].emit("message", Buffer.from(JSON.stringify(["EVENT", "clave-watch", event])));
+  assert.equal(received.length, 1);
+  assert.equal(received[0].url, "wss://a");
+  assert.deepEqual(received[0].evt, event);
+});
+
+test("message handler ignores non-EVENT messages", () => {
+  const factory = makeFactory();
+  const received = [];
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    onEvent: (url, evt) => received.push({ url, evt }),
+  });
+  pool.addRelay("wss://a");
+  factory.sockets[0]._openFromServer();
+  factory.sockets[0].emit("message", Buffer.from(JSON.stringify(["EOSE", "clave-watch"])));
+  factory.sockets[0].emit("message", Buffer.from(JSON.stringify(["NOTICE", "hello"])));
+  assert.equal(received.length, 0);
+});
+
+test("message handler ignores messages with wrong subscription id", () => {
+  const factory = makeFactory();
+  const received = [];
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    onEvent: (url, evt) => received.push({ url, evt }),
+  });
+  pool.addRelay("wss://a");
+  factory.sockets[0]._openFromServer();
+  const event = { id: "e1", kind: 24133, pubkey: "c1", tags: [["p", "s1"]], content: "..." };
+  factory.sockets[0].emit("message", Buffer.from(JSON.stringify(["EVENT", "other-sub", event])));
+  assert.equal(received.length, 0);
+});


### PR DESCRIPTION
## Summary

- Adds proxy-per-client-relay V2: iOS notifies the proxy of each nostrconnect pair's URI relays via NIP-98-signed HTTP; the proxy maintains ref-counted WebSocket subs across the union of paired relays, filtered by \`#p\` on registered signer pubkeys; signed responses publish back on the origin relay via \`responseRelayUrl\` plumbed through to \`LightSigner\`.
- Unblocks external TestFlight promotion past build 18 by restoring fevela / nostr-tools-family signing that regressed when [#7](https://github.com/DocNR/clave/pull/7) landed \`switch_relays → null\`.
- Also fixes the swipe-to-unpair UI bug (row animated away then reappeared when confirmation alert opened).

## Spec + diagnostic

- **Design spec:** \`~/hq/clave/specs/2026-04-20-proxy-per-client-relay-v2-design.md\` (Syncthing workspace — not in the repo).
- **Five-probe diagnostic that validated the architecture end-to-end:** \`~/hq/clave/troubleshooting/2026-04-19-switch-relays-nsec-app-e2e.md\`.

## Proxy changes (\`relay-proxy/\`)

- \`clients.js\` (new) — per-pair storage module, atomic temp-file + rename writes, 19 unit tests.
- \`relayPool.js\` (new) — ref-counted secondary-relay WebSocket fan-out, narrow \`{kinds:[24133], "#p":[...]}\` REQ, \`refreshFilter\` on signer set change, exponential reconnect backoff, heartbeat/pong-timeout, 18 unit tests.
- \`proxy.js\` — new \`POST /pair-client\` + \`POST /unpair-client\` (NIP-98 authenticated, parallel to \`/register\`); shared \`dispatchCaughtEvent\` pipeline for both primary and secondary; per-event \`relay_url\` in APNs payload; \`[Compliance]\` log line; boot-time restoration from \`clients.json\`; \`refreshFilter\` hooks on \`/register\` + \`/unregister\`.

## iOS changes (\`Clave/\`)

- \`LightSigner.handleRequest(responseRelayUrl:)\` — fixes the probe E hardcode that sent responses to \`relay.powr.build\` regardless of origin.
- \`NotificationService\` + \`AppDelegate\` foreground push handler thread \`userInfo["relay_url"]\` through.
- \`AppState.pairClientWithProxy\` + \`unpairClientWithProxy\` with \`pendingPairOps\` retry queue (cap 10, 3-strikes \`failCount\`, drains on foreground + successful \`/register\`).
- \`handleNostrConnect\` calls \`pairClientWithProxy\` after handshake success.
- \`deleteKey()\` bulk-unpairs before \`/unregister\`.
- \`HomeView\` + \`ClientDetailView\` unpair flows now call \`/unpair-client\` (was missing in initial plan — caught in code review).
- 5-pair cap enforced pre-flight in \`ApprovalSheet\` (nostrconnect) and \`LightSigner\` bunker first-connect.
- Swipe-to-unpair on \`HomeView\` now uses \`.swipeActions\` instead of \`.onDelete\` — no more phantom row-reappearing when Cancel is tapped on the confirmation alert.

## Resource caps

Enforced on proxy, mirrored pre-flight on iOS:

- ≤ 10 relays per pairing
- ≤ 5 paired clients per signer (free tier; future paid = 25)
- ≤ 50 novel relays per signer (URLs not already in the pool)

No global hard cap — replaced with operator alerting at 500 unique relays / 80% FD limit (alerting not yet implemented, acceptable per spec).

## Test plan

### Unit tests

- [x] Proxy: \`node --test test/clients.test.js test/relayPool.test.js test/storage.test.js\` — 64 tests pass on Mac (\`nip98.test.js\` requires \`@noble/curves\` present on Dell only; unchanged behavior).
- [x] iOS: \`xcodebuild build -scheme Clave\` succeeds on simulator destination. Existing \`LightSignerPeekMethodTests\`, \`LightSignerProcessRequestTests\`, \`NostrConnectParserTests\`, \`LightEventNip98Tests\`, \`AppStateMultiRelayHelpersTests\` unchanged. New \`LightSignerResponseRelayUrlTests.swift\` exists on disk but not yet in the xcodeproj test target (parameter presence is compile-time verified by NSE + AppDelegate calling \`handleRequest\` with \`responseRelayUrl:\`).

### Verification matrix (build 21 on internal TestFlight, Clave backgrounded)

| # | Client | URI flow | Expected |
|---|---|---|---|
| 1 | Coracle | nostrconnect | Pair + sign kind:1 ✓ |
| 2 | fevela | nostrconnect | Pair + sign kind:1 ✓ |
| 3 | noStrudel | nostrconnect (NOT relay.nsec.app) | Pair + sign kind:1 ✓ |
| 4 | zap.cooking | nostrconnect | Pair + sign kind:1 ✓ *or documented upstream bug* |
| 5 | plebsvszombies | nostrconnect | Pair + sign kind:1 ✓ *or documented upstream bug* |
| 6 | Nostur | bunker | Pair + sign kind:1 ✓ (regression check) |
| 7 | Unpair flow | any | Refcount drops; secondary subs close when last pair drops |
| 8 | Cap boundary | 6th pair | \`409\` + iOS toast |
| 9 | Offline pair | airplane mode | \`PairOp\` queued; drains on network return |

Items 1-3, 6, 7, 8, 9 must pass to promote external. Items 4-5 can ship with upstream-bug annotations.

## Deploy checklist

1. Merge this PR.
2. SSH Dell → \`git pull\` → \`sudo cp relay-proxy/{proxy,clients,relayPool}.js /opt/clave-proxy/\` → \`sudo systemctl restart clave-proxy\`.
3. Bump pbxproj to build 21 (small commit on main).
4. Archive + upload to internal TestFlight from Xcode.
5. Run verification matrix above on a real device.
6. If matrix passes: promote external, tag \`v0.1.0-build21\`, publish GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)