### PR TITLE
Build 22: response-delivery fixes (push-embed + pending relay-URL)

### DIFF
--- a/Clave/AppState.swift
+++ b/Clave/AppState.swift
@@ -289,7 +289,7 @@ final class AppState {
                 privateKey: privateKey,
                 requestEvent: requestEvent,
                 skipProtection: true,
-                responseRelayUrl: request.relayUrl
+                responseRelayUrl: request.responseRelayUrl
             )
             SharedStorage.removePendingRequest(id: request.id)
             refreshPendingRequests()

--- a/Clave/AppState.swift
+++ b/Clave/AppState.swift
@@ -285,7 +285,12 @@ final class AppState {
         }
 
         do {
-            let result = try await LightSigner.handleRequest(privateKey: privateKey, requestEvent: requestEvent, skipProtection: true)
+            let result = try await LightSigner.handleRequest(
+                privateKey: privateKey,
+                requestEvent: requestEvent,
+                skipProtection: true,
+                responseRelayUrl: request.relayUrl
+            )
             SharedStorage.removePendingRequest(id: request.id)
             refreshPendingRequests()
             return result.status == "signed"

--- a/Clave/ClaveApp.swift
+++ b/Clave/ClaveApp.swift
@@ -111,7 +111,11 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                 logger.notice("[App] Using embedded event from push payload")
                 events = [embedded]
             } else {
-                logger.notice("[App] No embedded event; fetching from \(relayUrlString, privacy: .public)")
+                if userInfo["event"] != nil {
+                    logger.warning("[App] event key present but not castable to [String: Any] — falling back to relay fetch")
+                } else {
+                    logger.notice("[App] No embedded event; fetching from \(relayUrlString, privacy: .public)")
+                }
                 let relay = LightRelay(url: relayUrlString)
                 try await relay.connect()
 

--- a/Clave/ClaveApp.swift
+++ b/Clave/ClaveApp.swift
@@ -103,32 +103,42 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         let relayUrlString = (userInfo["relay_url"] as? String) ?? SharedConstants.relayURL
 
         do {
-            let relay = LightRelay(url: relayUrlString)
-            try await relay.connect()
+            var events: [[String: Any]] = []
 
-            let now = Int(Date().timeIntervalSince1970)
-            // NIP-46 spec: clients MUST include ["p", <signer-pubkey>] on kind:24133
-            let filter: [String: Any] = [
-                "kinds": [24133],
-                "#p": [signerPubkey],
-                "since": now - 60,
-                "limit": 5
-            ]
+            // Prefer embedded event from the push payload. See NotificationService.swift
+            // for rationale — same fix, same race, same fallback.
+            if let embedded = userInfo["event"] as? [String: Any] {
+                logger.notice("[App] Using embedded event from push payload")
+                events = [embedded]
+            } else {
+                logger.notice("[App] No embedded event; fetching from \(relayUrlString, privacy: .public)")
+                let relay = LightRelay(url: relayUrlString)
+                try await relay.connect()
 
-            var events = try await relay.fetchEvents(filter: filter, timeout: 10.0)
-
-            if events.isEmpty {
-                try await Task.sleep(nanoseconds: 2_000_000_000)
-                let retryFilter: [String: Any] = [
+                let now = Int(Date().timeIntervalSince1970)
+                // NIP-46 spec: clients MUST include ["p", <signer-pubkey>] on kind:24133
+                let filter: [String: Any] = [
                     "kinds": [24133],
                     "#p": [signerPubkey],
-                    "since": now - 120,
+                    "since": now - 60,
                     "limit": 5
                 ]
-                events = try await relay.fetchEvents(filter: retryFilter, timeout: 10.0)
-            }
 
-            relay.disconnect()
+                events = try await relay.fetchEvents(filter: filter, timeout: 10.0)
+
+                if events.isEmpty {
+                    try await Task.sleep(nanoseconds: 2_000_000_000)
+                    let retryFilter: [String: Any] = [
+                        "kinds": [24133],
+                        "#p": [signerPubkey],
+                        "since": now - 120,
+                        "limit": 5
+                    ]
+                    events = try await relay.fetchEvents(filter: retryFilter, timeout: 10.0)
+                }
+
+                relay.disconnect()
+            }
 
             let processedKey = "processedEventIDs"
             var processedIDs = Set(SharedConstants.sharedDefaults.stringArray(forKey: processedKey) ?? [])

--- a/ClaveNSE/NotificationService.swift
+++ b/ClaveNSE/NotificationService.swift
@@ -110,32 +110,44 @@ class NotificationService: UNNotificationServiceExtension {
         let relayUrlString = (userInfo["relay_url"] as? String) ?? SharedConstants.relayURL
 
         do {
-            let relay = LightRelay(url: relayUrlString)
-            try await relay.connect()
+            var events: [[String: Any]] = []
 
-            let now = Int(Date().timeIntervalSince1970)
-            // NIP-46 spec: clients MUST include ["p", <signer-pubkey>] on kind:24133
-            let filter: [String: Any] = [
-                "kinds": [24133],
-                "#p": [signerPubkey],
-                "since": now - 60,
-                "limit": 5
-            ]
+            // Prefer the embedded event from the push payload (build 22+). This
+            // bypasses the ephemeral-fetch race where the relay drops kind:24133
+            // before NSE can REQ for it. If absent (older proxy or oversized
+            // event), fall through to the existing fetch-from-relay path.
+            if let embedded = userInfo["event"] as? [String: Any] {
+                logger.notice("[ClaveNSE] Using embedded event from push payload")
+                events = [embedded]
+            } else {
+                logger.notice("[ClaveNSE] No embedded event; fetching from \(relayUrlString, privacy: .public)")
+                let relay = LightRelay(url: relayUrlString)
+                try await relay.connect()
 
-            var events = try await relay.fetchEvents(filter: filter, timeout: 10.0)
-
-            if events.isEmpty {
-                try await Task.sleep(nanoseconds: 2_000_000_000)
-                let retryFilter: [String: Any] = [
+                let now = Int(Date().timeIntervalSince1970)
+                // NIP-46 spec: clients MUST include ["p", <signer-pubkey>] on kind:24133
+                let filter: [String: Any] = [
                     "kinds": [24133],
                     "#p": [signerPubkey],
-                    "since": now - 120,
+                    "since": now - 60,
                     "limit": 5
                 ]
-                events = try await relay.fetchEvents(filter: retryFilter, timeout: 10.0)
-            }
 
-            relay.disconnect()
+                events = try await relay.fetchEvents(filter: filter, timeout: 10.0)
+
+                if events.isEmpty {
+                    try await Task.sleep(nanoseconds: 2_000_000_000)
+                    let retryFilter: [String: Any] = [
+                        "kinds": [24133],
+                        "#p": [signerPubkey],
+                        "since": now - 120,
+                        "limit": 5
+                    ]
+                    events = try await relay.fetchEvents(filter: retryFilter, timeout: 10.0)
+                }
+
+                relay.disconnect()
+            }
 
             if events.isEmpty {
                 return SigningResult(status: .noEvents)

--- a/ClaveNSE/NotificationService.swift
+++ b/ClaveNSE/NotificationService.swift
@@ -120,7 +120,11 @@ class NotificationService: UNNotificationServiceExtension {
                 logger.notice("[ClaveNSE] Using embedded event from push payload")
                 events = [embedded]
             } else {
-                logger.notice("[ClaveNSE] No embedded event; fetching from \(relayUrlString, privacy: .public)")
+                if userInfo["event"] != nil {
+                    logger.warning("[ClaveNSE] event key present but not castable to [String: Any] — falling back to relay fetch")
+                } else {
+                    logger.notice("[ClaveNSE] No embedded event; fetching from \(relayUrlString, privacy: .public)")
+                }
                 let relay = LightRelay(url: relayUrlString)
                 try await relay.connect()
 

--- a/Shared/LightSigner.swift
+++ b/Shared/LightSigner.swift
@@ -197,7 +197,8 @@ enum LightSigner {
                             method: method,
                             eventKind: eventKind ?? 0,
                             clientPubkey: senderPubkey,
-                            timestamp: Date().timeIntervalSince1970
+                            timestamp: Date().timeIntervalSince1970,
+                            relayUrl: responseRelayUrl
                         )
                         SharedStorage.queuePendingRequest(pending)
                     }

--- a/Shared/LightSigner.swift
+++ b/Shared/LightSigner.swift
@@ -198,7 +198,7 @@ enum LightSigner {
                             eventKind: eventKind ?? 0,
                             clientPubkey: senderPubkey,
                             timestamp: Date().timeIntervalSince1970,
-                            relayUrl: responseRelayUrl
+                            responseRelayUrl: responseRelayUrl
                         )
                         SharedStorage.queuePendingRequest(pending)
                     }

--- a/Shared/SharedModels.swift
+++ b/Shared/SharedModels.swift
@@ -23,11 +23,11 @@ struct PendingRequest: Codable, Identifiable {
     /// to the same relay the client is actually subscribed on — not the
     /// powr.build fallback.
     ///
-    /// Optional for forward compatibility — Codable decodes missing keys on
+    /// Optional for backward compatibility — Codable decodes missing keys on
     /// Optional properties as nil without throwing, so pre-build-22 rows in
     /// UserDefaults decode cleanly and fall back to SharedConstants.relayURL
     /// at publish time.
-    let relayUrl: String?
+    let responseRelayUrl: String?
 }
 
 struct ConnectedClient: Codable, Identifiable {

--- a/Shared/SharedModels.swift
+++ b/Shared/SharedModels.swift
@@ -18,6 +18,16 @@ struct PendingRequest: Codable, Identifiable {
     let eventKind: Int?
     let clientPubkey: String
     let timestamp: Double
+    /// Relay URL the request was received on. Threaded back into
+    /// LightSigner.handleRequest at approval-time so the response publishes
+    /// to the same relay the client is actually subscribed on — not the
+    /// powr.build fallback.
+    ///
+    /// Optional for forward compatibility — Codable decodes missing keys on
+    /// Optional properties as nil without throwing, so pre-build-22 rows in
+    /// UserDefaults decode cleanly and fall back to SharedConstants.relayURL
+    /// at publish time.
+    let relayUrl: String?
 }
 
 struct ConnectedClient: Codable, Identifiable {

--- a/relay-proxy/proxy.js
+++ b/relay-proxy/proxy.js
@@ -575,6 +575,20 @@ async function dispatchCaughtEvent({ event, sourceUrl, classification }) {
     event_id: event.id,
   };
 
+  // Embed the caught event so NSE doesn't have to race the relay's ephemeral
+  // retention window. APNs alert payload cap is 4KB; 3500B leaves ~300B for
+  // the aps container. Oversized events fall through to NSE's existing
+  // fetch-from-relay path (same broken behavior as build 21, no regression).
+  const eventJSON = JSON.stringify(event);
+  const eventBytes = Buffer.byteLength(eventJSON);
+  if (eventBytes <= 3500) {
+    pushPayload.event = event;
+  } else {
+    console.log(
+      `[Push] Event ${event.id.slice(0, 8)} too large (${eventBytes}B), omitting embed — NSE will fall back to relay fetch`
+    );
+  }
+
   for (const entry of matchingTokens) {
     try {
       const status = await sendPush(entry.token, pushPayload);


### PR DESCRIPTION
## Summary

Two bug fixes bundled for build 22 — both on the "response delivery reliability" surface surfaced by build 21 matrix testing:

- **Payload-embed** (proxy + NSE + foreground): proxy now size-gates the caught kind:24133 event into the APNs push payload (≤3500B). NSE and foreground push handler prefer the embedded event over the existing fetch-from-relay path, closing the ephemeral-drop race that made fevela / noStrudel / Coracle flake on signing.
- **Pending relay-URL** (SharedModels + LightSigner + AppState): `PendingRequest` now stores the origin relay URL (`responseRelayUrl: String?`), so approve-later publishes land on the relay the client is actually subscribed on instead of the `relay.powr.build` fallback. Latent bug since PR #7 (`switch_relays → null`) — nostr-tools-family clients stopped migrating to powr.build, so the fallback stopped matching. Bunker flow was unaffected because Clave's bunker URIs are pinned to powr.build.

Design doc: \`~/hq/clave/specs/2026-04-20-response-delivery-fixes-design.md\`
Plan: \`~/hq/clave/plans/2026-04-20-response-delivery-fixes.md\`

## Changes

- \`relay-proxy/proxy.js\`: ~7 lines in \`dispatchCaughtEvent\` — size-gate \`event\` embed in push payload
- \`ClaveNSE/NotificationService.swift\`: ~15 lines in \`handleSigningRequest\` — prefer embedded event, fall through to fetch; distinguish cast-miss log from key-missing log
- \`Clave/ClaveApp.swift\`: ~15 lines in \`handleForegroundSigningRequest\` — same pattern as NSE
- \`Shared/SharedModels.swift\`: +1 field \`responseRelayUrl: String?\` on \`PendingRequest\` (Optional → default Codable synthesis handles pre-build-22 rows as nil)
- \`Shared/LightSigner.swift\`: capture \`responseRelayUrl\` into PendingRequest at queue-time
- \`Clave/AppState.swift\`: thread \`request.responseRelayUrl\` back to \`handleRequest\` at approve-time

~30 lines of net diff across 6 files. 5 commits (2 of which are small quality-review follow-ups).

Backward-compatible in both skew directions (build 21 app + build 22 proxy, build 22 app + build 21 proxy). Pre-build-22 pending rows decode with \`responseRelayUrl: nil\` and fall back to powr.build — unchanged broken behavior for pre-upgrade stragglers, accepted per spec as one-time degradation.

**No new unit tests** — manual matrix verification only for build 22 per sprint decision. Backlogged: \`push-payload.test.js\` (proxy) and \`NotificationServiceTests\` (iOS). Local Node 18 dev env has a pre-existing \`nip98.test.js\` failure (ESM \`require\` incompat with \`@noble/curves@2.2.0\` — Dell runs Node 20+ where this passes); not introduced by this PR.

## Test plan

- [ ] Existing proxy tests pass locally on Node 20+ (Dell deploy target)
- [ ] Xcode \`Cmd+U\` — all existing iOS unit tests pass
- [ ] Deploy proxy to Dell, verify \`[Push]\` log line on first caught event post-restart
- [ ] Build 22 installed via internal TestFlight
- [ ] Matrix:
  - [ ] Nostur bunker kind:1 auto-sign (regression)
  - [ ] Nostur bunker kind:10002 pending approval (regression)
  - [ ] fevela nostrconnect cold-start kind:1 (post-5-min-wait) — **must work**
  - [ ] fevela nostrconnect kind:10002 pending approval — **must work**
  - [ ] noStrudel nostrconnect kind:1 — **must work**
  - [ ] Coracle nostrconnect kind:1 (established npub) — **must work**
  - [ ] Coracle nostrconnect kind:10002 pending approval — **must work**
  - [ ] Cap boundary: 6th pair rejected
  - [ ] Offline pair: pending pair op drains on resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)