### PR TITLE
L1: foreground relay subscription (~25x speedup while Clave is open)

### DIFF
--- a/Clave.xcodeproj/project.pbxproj
+++ b/Clave.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		DD90DE0C2D8944D08B23C606 /* ClientPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894FE9FF88CD485ABCD31C05 /* ClientPermissions.swift */; };
 		DE7E10B2DE7E10B2DE7E10B2 /* DeveloperSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10B1DE7E10B1DE7E10B1 /* DeveloperSettings.swift */; };
 		DE7E10B3DE7E10B3DE7E10B3 /* DeveloperSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10B1DE7E10B1DE7E10B1 /* DeveloperSettings.swift */; };
-		F60FCE012F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60FCE002F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift */; };
 		DE7E10C2DE7E10C2DE7E10C2 /* LogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10C1DE7E10C1DE7E10C1 /* LogExporter.swift */; };
 		DE7E10C3DE7E10C3DE7E10C3 /* LogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10C1DE7E10C1DE7E10C1 /* LogExporter.swift */; };
 		EF1963B89F3A6472380F1E0A /* LightRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D7A5B2F8BD020005A6545 /* LightRelay.swift */; };
@@ -39,6 +38,7 @@
 		EFBF443D3DA775A267700410 /* Bech32.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D7A582F8BD020005A6545 /* Bech32.swift */; };
 		EFC7FD75109694C0A7F86D26 /* SharedModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFCA55B463A619311A35AF3C /* SharedModels.swift */; };
 		EFE12D1EC4CE48622767D427 /* SharedStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEE4316AC522CDDA35AFAC1 /* SharedStorage.swift */; };
+		F60FCE012F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60FCE002F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -83,7 +83,6 @@
 		34B139A8E147475F9B40B3D5 /* NostrConnectParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrConnectParser.swift; sourceTree = "<group>"; };
 		894FE9FF88CD485ABCD31C05 /* ClientPermissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientPermissions.swift; sourceTree = "<group>"; };
 		DE7E10B1DE7E10B1DE7E10B1 /* DeveloperSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperSettings.swift; sourceTree = "<group>"; };
-		F60FCE002F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForegroundRelaySubscription.swift; sourceTree = "<group>"; };
 		DE7E10C1DE7E10C1DE7E10C1 /* LogExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogExporter.swift; sourceTree = "<group>"; };
 		EF3D7A0F2F8BCAE3005A6545 /* Clave.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Clave.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EF3D7A1C2F8BCAE6005A6545 /* ClaveTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ClaveTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -99,6 +98,7 @@
 		EF3D7A5F2F8BD020005A6545 /* SignerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignerService.swift; sourceTree = "<group>"; };
 		EFCA55B463A619311A35AF3C /* SharedModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedModels.swift; sourceTree = "<group>"; };
 		EFEE4316AC522CDDA35AFAC1 /* SharedStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStorage.swift; sourceTree = "<group>"; };
+		F60FCE002F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForegroundRelaySubscription.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */

--- a/Clave.xcodeproj/project.pbxproj
+++ b/Clave.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		DD90DE0C2D8944D08B23C606 /* ClientPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894FE9FF88CD485ABCD31C05 /* ClientPermissions.swift */; };
 		DE7E10B2DE7E10B2DE7E10B2 /* DeveloperSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10B1DE7E10B1DE7E10B1 /* DeveloperSettings.swift */; };
 		DE7E10B3DE7E10B3DE7E10B3 /* DeveloperSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10B1DE7E10B1DE7E10B1 /* DeveloperSettings.swift */; };
+		F60FCE012F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60FCE002F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift */; };
 		DE7E10C2DE7E10C2DE7E10C2 /* LogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10C1DE7E10C1DE7E10C1 /* LogExporter.swift */; };
 		DE7E10C3DE7E10C3DE7E10C3 /* LogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10C1DE7E10C1DE7E10C1 /* LogExporter.swift */; };
 		EF1963B89F3A6472380F1E0A /* LightRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D7A5B2F8BD020005A6545 /* LightRelay.swift */; };
@@ -82,6 +83,7 @@
 		34B139A8E147475F9B40B3D5 /* NostrConnectParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrConnectParser.swift; sourceTree = "<group>"; };
 		894FE9FF88CD485ABCD31C05 /* ClientPermissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientPermissions.swift; sourceTree = "<group>"; };
 		DE7E10B1DE7E10B1DE7E10B1 /* DeveloperSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperSettings.swift; sourceTree = "<group>"; };
+		F60FCE002F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForegroundRelaySubscription.swift; sourceTree = "<group>"; };
 		DE7E10C1DE7E10C1DE7E10C1 /* LogExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogExporter.swift; sourceTree = "<group>"; };
 		EF3D7A0F2F8BCAE3005A6545 /* Clave.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Clave.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EF3D7A1C2F8BCAE6005A6545 /* ClaveTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ClaveTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -209,6 +211,7 @@
 				EF3D7A582F8BD020005A6545 /* Bech32.swift */,
 				894FE9FF88CD485ABCD31C05 /* ClientPermissions.swift */,
 				DE7E10B1DE7E10B1DE7E10B1 /* DeveloperSettings.swift */,
+				F60FCE002F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift */,
 				DE7E10C1DE7E10C1DE7E10C1 /* LogExporter.swift */,
 				34B139A8E147475F9B40B3D5 /* NostrConnectParser.swift */,
 				EF3D7A592F8BD020005A6545 /* LightCrypto.swift */,
@@ -423,6 +426,7 @@
 				EF1963B89F3A6472380F1E0A /* LightRelay.swift in Sources */,
 				EF85F076F6C02095C4B6D9C4 /* LightSigner.swift in Sources */,
 				DE7E10B2DE7E10B2DE7E10B2 /* DeveloperSettings.swift in Sources */,
+				F60FCE012F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift in Sources */,
 				DE7E10C2DE7E10C2DE7E10C2 /* LogExporter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Clave/AppState.swift
+++ b/Clave/AppState.swift
@@ -583,6 +583,15 @@ final class AppState {
     /// subscriptions. Fire-and-forget from the caller's perspective; failures
     /// are queued in SharedStorage.pendingPairOps for later retry.
     func pairClientWithProxy(clientPubkey: String, relayUrls: [String]) {
+        // Persist the client's URI relay set locally first (used by Layer 1's
+        // foreground subscription). Idempotent.
+        SharedStorage.setClientRelayUrls(pubkey: clientPubkey, relayUrls: relayUrls)
+
+        // Layer 1: relay-set may have changed; refresh the foreground sub.
+        Task { @MainActor in
+            ForegroundRelaySubscription.shared.refreshRelaySet()
+        }
+
         guard let nsec = SharedKeychain.loadNsec() else { return }
         let privateKey: Data
         do {
@@ -640,6 +649,12 @@ final class AppState {
 
     /// Notify the proxy of an unpair. Same failure semantics as pair.
     func unpairClientWithProxy(clientPubkey: String) {
+        // Layer 1: the unpaired client's URI relays may no longer be needed
+        // in the foreground sub's set. Refresh.
+        Task { @MainActor in
+            ForegroundRelaySubscription.shared.refreshRelaySet()
+        }
+
         guard let nsec = SharedKeychain.loadNsec() else { return }
         let privateKey: Data
         do {

--- a/Clave/AppState.swift
+++ b/Clave/AppState.swift
@@ -47,6 +47,21 @@ final class AppState {
         }
     }
 
+    // MARK: - Foreground subscription bridge
+
+    /// Bridges into the `@MainActor`-isolated ForegroundRelaySubscription. Called
+    /// from a SwiftUI scenePhase observer in the root view. AppState itself is
+    /// not `@MainActor`, so the hop happens here.
+    @MainActor
+    func startForegroundSubscription() {
+        ForegroundRelaySubscription.shared.start()
+    }
+
+    @MainActor
+    func stopForegroundSubscription() {
+        ForegroundRelaySubscription.shared.stop()
+    }
+
     var npub: String {
         guard !signerPubkeyHex.isEmpty,
               let pubkey = try? PublicKey.parse(publicKey: signerPubkeyHex) else { return "" }

--- a/Clave/ClaveApp.swift
+++ b/Clave/ClaveApp.swift
@@ -144,8 +144,10 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                 relay.disconnect()
             }
 
-            let processedKey = "processedEventIDs"
-            var processedIDs = Set(SharedConstants.sharedDefaults.stringArray(forKey: processedKey) ?? [])
+            // Per-event dedupe is now done inside LightSigner.handleRequest
+            // (audit D.1.1, see SharedStorage.markEventProcessed). Duplicates
+            // arriving via both APNs and the foreground subscription return
+            // status "skipped-duplicate" without doing decrypt work.
 
             var handledCount = 0
             // Process connects first so pairing state exists before other methods.
@@ -159,9 +161,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 
             for event in sortedEvents {
                 guard let eventPubkey = event["pubkey"] as? String,
-                      eventPubkey != signerPubkey,
-                      let eventId = event["id"] as? String,
-                      !processedIDs.contains(eventId) else { continue }
+                      eventPubkey != signerPubkey else { continue }
 
                 do {
                     let result = try await LightSigner.handleRequest(
@@ -169,19 +169,17 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                         requestEvent: event,
                         responseRelayUrl: relayUrlString
                     )
-                    processedIDs.insert(eventId)
                     if result.status == "error" && result.errorMessage == "Decrypt failed" {
+                        continue
+                    }
+                    if result.status == "skipped-duplicate" {
                         continue
                     }
                     handledCount += 1
                 } catch {
-                    processedIDs.insert(eventId)
                     logger.notice("[App] Skipping event: \(error.localizedDescription)")
                 }
             }
-
-            let trimmed = Array(processedIDs.suffix(50))
-            SharedConstants.sharedDefaults.set(trimmed, forKey: processedKey)
 
             logger.notice("[App] Foreground handled \(handledCount) requests")
 

--- a/Clave/Info.plist
+++ b/Clave/Info.plist
@@ -10,14 +10,5 @@
 	<string>Authenticate to view or export your secret key</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<!-- Allow plain ws:// to local-network hosts (e.g. nak serve on
-		     developer's Mac LAN) for the L1 verification matrix. iOS still
-		     enforces TLS for WAN connections; this is local-only. Production
-		     traffic uses wss://relay.powr.build (TLS-required). -->
-		<key>NSAllowsLocalNetworking</key>
-		<true/>
-	</dict>
 </dict>
 </plist>

--- a/Clave/Info.plist
+++ b/Clave/Info.plist
@@ -10,5 +10,14 @@
 	<string>Authenticate to view or export your secret key</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<!-- Allow plain ws:// to local-network hosts (e.g. nak serve on
+		     developer's Mac LAN) for the L1 verification matrix. iOS still
+		     enforces TLS for WAN connections; this is local-only. Production
+		     traffic uses wss://relay.powr.build (TLS-required). -->
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/Clave/Views/MainTabView.swift
+++ b/Clave/Views/MainTabView.swift
@@ -1,6 +1,13 @@
 import SwiftUI
 
 struct MainTabView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.scenePhase) private var scenePhase
+
+    /// Pending stop deferred during the .inactive grace window. Cancelled if
+    /// .active resumes within 2s (e.g. control-center swipe, app-switcher peek).
+    @State private var pendingStopTask: Task<Void, Never>? = nil
+
     var body: some View {
         TabView {
             HomeView()
@@ -17,6 +24,38 @@ struct MainTabView: View {
                 .tabItem {
                     Label("Settings", systemImage: "gearshape.fill")
                 }
+        }
+        .onChange(of: scenePhase) { _, phase in
+            handleScenePhase(phase)
+        }
+    }
+
+    private func handleScenePhase(_ phase: ScenePhase) {
+        switch phase {
+        case .active:
+            // Cancel any pending stop and start the foreground subscription.
+            pendingStopTask?.cancel()
+            pendingStopTask = nil
+            Task { @MainActor in
+                appState.startForegroundSubscription()
+            }
+        case .inactive:
+            // 2s grace window for app-switcher peeks / control-center swipes.
+            pendingStopTask?.cancel()
+            pendingStopTask = Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                guard !Task.isCancelled else { return }
+                appState.stopForegroundSubscription()
+            }
+        case .background:
+            // Confirmed background — stop immediately.
+            pendingStopTask?.cancel()
+            pendingStopTask = nil
+            Task { @MainActor in
+                appState.stopForegroundSubscription()
+            }
+        @unknown default:
+            break
         }
     }
 }

--- a/Clave/Views/Settings/SettingsView.swift
+++ b/Clave/Views/Settings/SettingsView.swift
@@ -10,10 +10,6 @@ struct SettingsView: View {
     @State private var devSettings = DeveloperSettings.shared
     @State private var versionTapTimes: [Date] = []
     @State private var showCopyLogsConfirmation = false
-    #if DEBUG
-    @State private var debugTestRelayDraft: String = ""
-    @State private var fgSub = ForegroundRelaySubscription.shared
-    #endif
 
     var body: some View {
         NavigationStack {
@@ -25,22 +21,11 @@ struct SettingsView: View {
                 aboutSection
                 if devSettings.developerMenuUnlocked {
                     developerSection
-                    #if DEBUG
-                    l1TestSection
-                    #endif
                 }
             }
             .navigationTitle("Settings")
             .onAppear {
                 loadSettings()
-                #if DEBUG
-                // Hydrate from persisted state. Done in onAppear (not in
-                // @State default) so re-creation of the view doesn't blow
-                // away in-progress edits.
-                if debugTestRelayDraft.isEmpty {
-                    debugTestRelayDraft = SharedStorage.getDebugTestRelay() ?? ""
-                }
-                #endif
             }
             .alert("Delete Key", isPresented: $showDeleteConfirmation) {
                 Button("Delete", role: .destructive) {
@@ -248,99 +233,4 @@ struct SettingsView: View {
         proxyURL = SharedConstants.sharedDefaults.string(forKey: SharedConstants.proxyURLKey)
             ?? SharedConstants.defaultProxyURL
     }
-
-    #if DEBUG
-    // MARK: - DEBUG: Layer 1 verification
-
-    /// DEBUG-only test override. Lets a developer add an extra relay to
-    /// the L1 foreground subscription set without going through a full
-    /// nostrconnect pair. Used during the L1 verification matrix
-    /// (~/hq/clave/plans/2026-04-26-foreground-relay-subscription.md
-    /// Task 10) to point L1 at `nak serve` on Mac LAN.
-    private var l1TestSection: some View {
-        Section("DEBUG: L1 Test Relay") {
-            HStack {
-                Text("Status")
-                Spacer()
-                HStack(spacing: 4) {
-                    Circle()
-                        .fill(l1StatusColor)
-                        .frame(width: 8, height: 8)
-                    Text(fgSub.state.rawValue)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                HStack {
-                    Text("Received")
-                    Spacer()
-                    Text("\(fgSub.eventsReceived)")
-                        .font(.system(.body, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                }
-                HStack {
-                    Text("Processed")
-                    Spacer()
-                    Text("\(fgSub.eventsProcessed)")
-                        .font(.system(.body, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                }
-                HStack {
-                    Text("Failed")
-                    Spacer()
-                    Text("\(fgSub.eventsFailed)")
-                        .font(.system(.body, design: .monospaced))
-                        .foregroundStyle(fgSub.eventsFailed > 0 ? .red : .secondary)
-                }
-            }
-
-            TextField("Extra relay URL (ws:// or wss://)", text: $debugTestRelayDraft)
-                .autocorrectionDisabled()
-                .textInputAutocapitalization(.never)
-                .font(.system(.body, design: .monospaced))
-
-            // Each Button gets its own row in the Form. Putting both inside
-            // a single HStack makes SwiftUI treat the whole row as one tap
-            // target and fire both actions on a single tap (observed in
-                // L1 verification: tapping Apply also fired Clear).
-            Button {
-                SharedStorage.setDebugTestRelay(debugTestRelayDraft)
-                ForegroundRelaySubscription.shared.refreshRelaySet()
-            } label: {
-                Label("Apply + Refresh", systemImage: "arrow.triangle.2.circlepath")
-            }
-            .buttonStyle(.borderless)
-
-            Button(role: .destructive) {
-                SharedStorage.setDebugTestRelay(nil)
-                debugTestRelayDraft = ""
-                ForegroundRelaySubscription.shared.refreshRelaySet()
-            } label: {
-                Label("Clear", systemImage: "xmark.circle")
-            }
-            .buttonStyle(.borderless)
-
-            if let err = fgSub.lastError {
-                Text(err)
-                    .font(.caption2)
-                    .foregroundStyle(.red)
-            }
-
-            Text("Adds an extra relay to L1's foreground subscription set. Used by the nip17-bulk-decrypt harness against `nak serve` on Mac LAN. NOT compiled in Release builds.")
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
-        }
-    }
-
-    private var l1StatusColor: Color {
-        switch fgSub.state {
-        case .listening: return .green
-        case .starting, .reconnecting: return .yellow
-        case .error: return .red
-        default: return .gray
-        }
-    }
-    #endif
 }

--- a/Clave/Views/Settings/SettingsView.swift
+++ b/Clave/Views/Settings/SettingsView.swift
@@ -10,6 +10,10 @@ struct SettingsView: View {
     @State private var devSettings = DeveloperSettings.shared
     @State private var versionTapTimes: [Date] = []
     @State private var showCopyLogsConfirmation = false
+    #if DEBUG
+    @State private var debugTestRelayDraft: String = SharedStorage.getDebugTestRelay() ?? ""
+    @State private var fgSub = ForegroundRelaySubscription.shared
+    #endif
 
     var body: some View {
         NavigationStack {
@@ -21,6 +25,9 @@ struct SettingsView: View {
                 aboutSection
                 if devSettings.developerMenuUnlocked {
                     developerSection
+                    #if DEBUG
+                    l1TestSection
+                    #endif
                 }
             }
             .navigationTitle("Settings")
@@ -231,4 +238,97 @@ struct SettingsView: View {
         proxyURL = SharedConstants.sharedDefaults.string(forKey: SharedConstants.proxyURLKey)
             ?? SharedConstants.defaultProxyURL
     }
+
+    #if DEBUG
+    // MARK: - DEBUG: Layer 1 verification
+
+    /// DEBUG-only test override. Lets a developer add an extra relay to
+    /// the L1 foreground subscription set without going through a full
+    /// nostrconnect pair. Used during the L1 verification matrix
+    /// (~/hq/clave/plans/2026-04-26-foreground-relay-subscription.md
+    /// Task 10) to point L1 at `nak serve` on Mac LAN.
+    private var l1TestSection: some View {
+        Section("DEBUG: L1 Test Relay") {
+            HStack {
+                Text("Status")
+                Spacer()
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(l1StatusColor)
+                        .frame(width: 8, height: 8)
+                    Text(fgSub.state.rawValue)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("Received")
+                    Spacer()
+                    Text("\(fgSub.eventsReceived)")
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text("Processed")
+                    Spacer()
+                    Text("\(fgSub.eventsProcessed)")
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text("Failed")
+                    Spacer()
+                    Text("\(fgSub.eventsFailed)")
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundStyle(fgSub.eventsFailed > 0 ? .red : .secondary)
+                }
+            }
+
+            TextField("Extra relay URL (ws:// or wss://)", text: $debugTestRelayDraft)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .font(.system(.body, design: .monospaced))
+
+            HStack {
+                Button {
+                    SharedStorage.setDebugTestRelay(debugTestRelayDraft)
+                    ForegroundRelaySubscription.shared.refreshRelaySet()
+                } label: {
+                    Label("Apply + Refresh", systemImage: "arrow.triangle.2.circlepath")
+                }
+
+                Spacer()
+
+                Button(role: .destructive) {
+                    SharedStorage.setDebugTestRelay(nil)
+                    debugTestRelayDraft = ""
+                    ForegroundRelaySubscription.shared.refreshRelaySet()
+                } label: {
+                    Label("Clear", systemImage: "xmark.circle")
+                }
+            }
+
+            if let err = fgSub.lastError {
+                Text(err)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+            }
+
+            Text("Adds an extra relay to L1's foreground subscription set. Used by the nip17-bulk-decrypt harness against `nak serve` on Mac LAN. NOT compiled in Release builds.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    private var l1StatusColor: Color {
+        switch fgSub.state {
+        case .listening: return .green
+        case .starting, .reconnecting: return .yellow
+        case .error: return .red
+        default: return .gray
+        }
+    }
+    #endif
 }

--- a/Clave/Views/Settings/SettingsView.swift
+++ b/Clave/Views/Settings/SettingsView.swift
@@ -301,24 +301,26 @@ struct SettingsView: View {
                 .textInputAutocapitalization(.never)
                 .font(.system(.body, design: .monospaced))
 
-            HStack {
-                Button {
-                    SharedStorage.setDebugTestRelay(debugTestRelayDraft)
-                    ForegroundRelaySubscription.shared.refreshRelaySet()
-                } label: {
-                    Label("Apply + Refresh", systemImage: "arrow.triangle.2.circlepath")
-                }
-
-                Spacer()
-
-                Button(role: .destructive) {
-                    SharedStorage.setDebugTestRelay(nil)
-                    debugTestRelayDraft = ""
-                    ForegroundRelaySubscription.shared.refreshRelaySet()
-                } label: {
-                    Label("Clear", systemImage: "xmark.circle")
-                }
+            // Each Button gets its own row in the Form. Putting both inside
+            // a single HStack makes SwiftUI treat the whole row as one tap
+            // target and fire both actions on a single tap (observed in
+                // L1 verification: tapping Apply also fired Clear).
+            Button {
+                SharedStorage.setDebugTestRelay(debugTestRelayDraft)
+                ForegroundRelaySubscription.shared.refreshRelaySet()
+            } label: {
+                Label("Apply + Refresh", systemImage: "arrow.triangle.2.circlepath")
             }
+            .buttonStyle(.borderless)
+
+            Button(role: .destructive) {
+                SharedStorage.setDebugTestRelay(nil)
+                debugTestRelayDraft = ""
+                ForegroundRelaySubscription.shared.refreshRelaySet()
+            } label: {
+                Label("Clear", systemImage: "xmark.circle")
+            }
+            .buttonStyle(.borderless)
 
             if let err = fgSub.lastError {
                 Text(err)

--- a/Clave/Views/Settings/SettingsView.swift
+++ b/Clave/Views/Settings/SettingsView.swift
@@ -11,7 +11,7 @@ struct SettingsView: View {
     @State private var versionTapTimes: [Date] = []
     @State private var showCopyLogsConfirmation = false
     #if DEBUG
-    @State private var debugTestRelayDraft: String = SharedStorage.getDebugTestRelay() ?? ""
+    @State private var debugTestRelayDraft: String = ""
     @State private var fgSub = ForegroundRelaySubscription.shared
     #endif
 
@@ -31,7 +31,17 @@ struct SettingsView: View {
                 }
             }
             .navigationTitle("Settings")
-            .onAppear { loadSettings() }
+            .onAppear {
+                loadSettings()
+                #if DEBUG
+                // Hydrate from persisted state. Done in onAppear (not in
+                // @State default) so re-creation of the view doesn't blow
+                // away in-progress edits.
+                if debugTestRelayDraft.isEmpty {
+                    debugTestRelayDraft = SharedStorage.getDebugTestRelay() ?? ""
+                }
+                #endif
+            }
             .alert("Delete Key", isPresented: $showDeleteConfirmation) {
                 Button("Delete", role: .destructive) {
                     appState.deleteKey()

--- a/ClaveNSE/NotificationService.swift
+++ b/ClaveNSE/NotificationService.swift
@@ -157,8 +157,10 @@ class NotificationService: UNNotificationServiceExtension {
                 return SigningResult(status: .noEvents)
             }
 
-            let processedKey = "processedEventIDs"
-            var processedIDs = Set(SharedConstants.sharedDefaults.stringArray(forKey: processedKey) ?? [])
+            // Per-event dedupe is now done inside LightSigner.handleRequest
+            // (audit D.1.1, see SharedStorage.markEventProcessed). Duplicates
+            // arriving via both APNs and the foreground subscription return
+            // status "skipped-duplicate" without doing decrypt work.
 
             var lastError: String? = nil
             var handledCount = 0
@@ -178,9 +180,7 @@ class NotificationService: UNNotificationServiceExtension {
 
             for event in sortedEvents {
                 guard let eventPubkey = event["pubkey"] as? String,
-                      eventPubkey != signerPubkey,
-                      let eventId = event["id"] as? String,
-                      !processedIDs.contains(eventId) else { continue }
+                      eventPubkey != signerPubkey else { continue }
 
                 do {
                     let result = try await LightSigner.handleRequest(
@@ -188,9 +188,13 @@ class NotificationService: UNNotificationServiceExtension {
                         requestEvent: event,
                         responseRelayUrl: relayUrlString
                     )
-                    processedIDs.insert(eventId)
                     // Decrypt failures mean "not for us" — skip silently
                     if result.status == "error" && result.errorMessage == "Decrypt failed" {
+                        continue
+                    }
+                    if result.status == "skipped-duplicate" {
+                        // Layer 1 foreground sub or another NSE wake already
+                        // handled this event. No-op.
                         continue
                     }
                     handledCount += 1
@@ -205,13 +209,9 @@ class NotificationService: UNNotificationServiceExtension {
                     }
                 } catch {
                     // Treat errors as non-fatal — event may not be for us
-                    processedIDs.insert(eventId)
                     logger.notice("[ClaveNSE] Skipping event: \(error.localizedDescription)")
                 }
             }
-
-            let trimmed = Array(processedIDs.suffix(50))
-            SharedConstants.sharedDefaults.set(trimmed, forKey: processedKey)
 
             logger.notice("[ClaveNSE] Handled \(handledCount) new requests, skipped \(events.count - handledCount) duplicates")
 

--- a/ClaveTests/ForegroundRelaySubscriptionTests.swift
+++ b/ClaveTests/ForegroundRelaySubscriptionTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import Clave
+
+@MainActor
+final class ForegroundRelaySubscriptionTests: XCTestCase {
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // Clean state before each test.
+        let sub = ForegroundRelaySubscription.shared
+        sub.stop()
+        sub.resetCounters()
+        // Allow stop() to fully transition before next test starts.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+    }
+
+    override func tearDown() async throws {
+        // Ensure we leave the singleton idle for other test files.
+        let sub = ForegroundRelaySubscription.shared
+        sub.stop()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        try await super.tearDown()
+    }
+
+    func test_initialOrPostStopState_isIdle() async {
+        let sub = ForegroundRelaySubscription.shared
+        XCTAssertEqual(sub.state, .idle)
+    }
+
+    func test_startWithNoSignerKey_setsError() async {
+        // Clear any stored signer pubkey so the start path bails out.
+        SharedConstants.sharedDefaults.removeObject(forKey: SharedConstants.signerPubkeyHexKey)
+
+        let sub = ForegroundRelaySubscription.shared
+        sub.start()
+        XCTAssertEqual(sub.state, .error)
+        XCTAssertNotNil(sub.lastError)
+        XCTAssertTrue(sub.lastError?.contains("signer") == true)
+    }
+
+    func test_resetCounters_zeroesAll() {
+        let sub = ForegroundRelaySubscription.shared
+        sub.resetCounters()
+        XCTAssertEqual(sub.eventsReceived, 0)
+        XCTAssertEqual(sub.eventsProcessed, 0)
+        XCTAssertEqual(sub.eventsFailed, 0)
+        XCTAssertTrue(sub.recentLatenciesMs.isEmpty)
+        XCTAssertNil(sub.lastError)
+    }
+
+    func test_stopWhileIdle_isNoOp() {
+        let sub = ForegroundRelaySubscription.shared
+        let before = sub.state
+        sub.stop()
+        XCTAssertEqual(sub.state, before)
+        XCTAssertEqual(sub.state, .idle)
+    }
+
+    func test_startTwice_isIdempotent() {
+        // Set a valid-looking pubkey so start() doesn't bail out for that reason.
+        let fakePub = String(repeating: "0", count: 64)
+        SharedConstants.sharedDefaults.set(fakePub, forKey: SharedConstants.signerPubkeyHexKey)
+
+        let sub = ForegroundRelaySubscription.shared
+        sub.start()
+        let firstState = sub.state
+        sub.start()  // second call should not change state
+        XCTAssertEqual(sub.state, firstState)
+        sub.stop()
+
+        // Cleanup
+        SharedConstants.sharedDefaults.removeObject(forKey: SharedConstants.signerPubkeyHexKey)
+    }
+}

--- a/ClaveTests/SharedStorageDedupTests.swift
+++ b/ClaveTests/SharedStorageDedupTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import Clave
+
+final class SharedStorageDedupTests: XCTestCase {
+    private let testKey = "test.processedEventIDs"
+
+    override func setUp() {
+        super.setUp()
+        SharedConstants.sharedDefaults.removeObject(forKey: testKey)
+        SharedStorage._setProcessedEventIDsKeyForTesting(testKey)
+    }
+
+    override func tearDown() {
+        SharedConstants.sharedDefaults.removeObject(forKey: testKey)
+        SharedStorage._resetProcessedEventIDsKeyForTesting()
+        super.tearDown()
+    }
+
+    func test_firstSeenEvent_returnsMarkedNew() {
+        let now = Date().timeIntervalSince1970
+        let result = SharedStorage.markEventProcessed(eventId: "abc", createdAt: now)
+        XCTAssertEqual(result, .markedNew)
+    }
+
+    func test_repeatedEvent_returnsAlreadyProcessed() {
+        let now = Date().timeIntervalSince1970
+        _ = SharedStorage.markEventProcessed(eventId: "abc", createdAt: now)
+        let result = SharedStorage.markEventProcessed(eventId: "abc", createdAt: now)
+        XCTAssertEqual(result, .alreadyProcessed)
+    }
+
+    func test_ringBufferEvictsOldestPastCap() {
+        // Cap is 200. Insert 201 unique ids with fresh timestamps so age-eviction
+        // doesn't kick in. The first should be evicted by cap.
+        let now = Date().timeIntervalSince1970
+        for i in 0..<201 {
+            _ = SharedStorage.markEventProcessed(eventId: "id\(i)", createdAt: now)
+        }
+        // The very first id ("id0") should now NOT be considered processed.
+        let result = SharedStorage.markEventProcessed(eventId: "id0", createdAt: now)
+        XCTAssertEqual(result, .markedNew, "id0 should have been evicted past the 200-entry cap")
+    }
+
+    func test_oldEntries_evictedByAge() {
+        let now = Date().timeIntervalSince1970
+        let oldTs = now - 120  // 120s ago, beyond 60s window
+        _ = SharedStorage.markEventProcessed(eventId: "old", createdAt: oldTs)
+
+        // Inserting a fresh event triggers age-based eviction sweep.
+        _ = SharedStorage.markEventProcessed(eventId: "fresh", createdAt: now)
+
+        // "old" should now be evicted by age, so re-inserting returns markedNew.
+        let result = SharedStorage.markEventProcessed(eventId: "old", createdAt: oldTs)
+        XCTAssertEqual(result, .markedNew, "old entries should age out after 60s")
+    }
+
+    func test_concurrentMarks_serializeWithinProcess() async {
+        // 100 concurrent marks of the same id from the same process.
+        // Lossy semantics across processes are acceptable (see spec), but
+        // within one process serialization must hold.
+        let id = "concurrent"
+        let createdAt = Date().timeIntervalSince1970
+        let results: [SharedStorage.ProcessedStatus] = await withTaskGroup(
+            of: SharedStorage.ProcessedStatus.self,
+            returning: [SharedStorage.ProcessedStatus].self
+        ) { group in
+            for _ in 0..<100 {
+                group.addTask {
+                    SharedStorage.markEventProcessed(eventId: id, createdAt: createdAt)
+                }
+            }
+            var collected: [SharedStorage.ProcessedStatus] = []
+            for await r in group { collected.append(r) }
+            return collected
+        }
+        let newCount = results.filter { $0 == .markedNew }.count
+        XCTAssertEqual(newCount, 1, "exactly one task should see markedNew within one process")
+    }
+}

--- a/Shared/ForegroundRelaySubscription.swift
+++ b/Shared/ForegroundRelaySubscription.swift
@@ -52,31 +52,66 @@ final class ForegroundRelaySubscription {
     private(set) var recentLatenciesMs: [Double] = []
     private static let latencyRingCap = 1024
 
-    // MARK: - Internals (filled in subsequent tasks)
+    // MARK: - Internals
 
     private var dispatcherTask: Task<Void, Never>?
+
+    /// Default concurrency cap for per-event dispatch. Empirical sweet spot
+    /// from FINDINGS.md (S1k-c5 vs S1k-c20 showed no throughput gain past
+    /// concurrency=5, just queueing latency). Layer 2 may tune.
+    static let defaultConcurrency = 5
+
+    /// Per-event budget. Hard upper bound on a single LightSigner.handleRequest
+    /// invocation; if the publish path hangs, we cancel and free the slot.
+    static let perEventBudgetSeconds: UInt64 = 30
 
     private init() {}
 
     // MARK: - Public API
 
     func start() {
-        guard state == .idle || state == .error else { return }
+        guard state == .idle || state == .error else {
+            logger.notice("[fg-sub] start() called in state \(self.state.rawValue, privacy: .public) — no-op")
+            return
+        }
+
+        let userPubkey = SharedConstants.sharedDefaults.string(forKey: SharedConstants.signerPubkeyHexKey) ?? ""
+        if userPubkey.isEmpty {
+            lastError = "No signer key configured"
+            state = .error
+            statusMessage = "Error"
+            return
+        }
+
+        let relays = relaySet()
+        if relays.isEmpty {
+            lastError = "No relays configured (no paired clients)"
+            state = .error
+            statusMessage = "Error"
+            return
+        }
+
         state = .starting
         statusMessage = "Connecting…"
-        // TODO(Task 5): spawn dispatcher Task that runs withTaskGroup
-        // over the relay set and processes incoming kind:24133 events.
-        logger.notice("[fg-sub] start() called (skeleton — no-op until Task 5)")
+        eventsReceived = 0
+        eventsProcessed = 0
+        eventsFailed = 0
+        lastError = nil
+
+        logger.notice("[fg-sub] start: relays=\(relays.count) user=\(userPubkey.prefix(8), privacy: .public)…")
+
+        dispatcherTask = Task { [self] in
+            await self.runDispatcher(relays: relays, userPubkey: userPubkey)
+        }
     }
 
     func stop() {
         guard state != .idle else { return }
+        logger.notice("[fg-sub] stop() called from state=\(self.state.rawValue, privacy: .public)")
         state = .stopping
         dispatcherTask?.cancel()
         dispatcherTask = nil
-        state = .idle
-        statusMessage = "Idle"
-        logger.notice("[fg-sub] stop() called")
+        // dispatcher exits inside runDispatcher() which transitions back to .idle
     }
 
     func resetCounters() {
@@ -93,6 +128,236 @@ final class ForegroundRelaySubscription {
         recentLatenciesMs.append(ms)
         if recentLatenciesMs.count > Self.latencyRingCap {
             recentLatenciesMs.removeFirst(recentLatenciesMs.count - Self.latencyRingCap)
+        }
+    }
+
+    // MARK: - Relay set
+
+    /// Returns the union of relayUrls across paired clients, plus the primary
+    /// bunker relay as a guaranteed fallback. De-duplicated.
+    private func relaySet() -> [String] {
+        var set = Set<String>()
+        set.insert(SharedConstants.relayURL)
+        for client in SharedStorage.getConnectedClients() {
+            for url in client.relayUrls where !url.isEmpty {
+                set.insert(url)
+            }
+        }
+        return Array(set)
+    }
+
+    // MARK: - Dispatcher
+
+    private func runDispatcher(relays: [String], userPubkey: String) async {
+        // One long-lived TaskGroup per dispatcher run. Each child task is a
+        // per-relay loop that connects, REQs, processes events, reconnects on
+        // failure. The group ends when the dispatcherTask is cancelled (stop()).
+        await withTaskGroup(of: Void.self) { group in
+            for relay in relays {
+                group.addTask { [self] in
+                    await self.runRelayLoop(relayURL: relay, userPubkey: userPubkey)
+                }
+            }
+            // Group blocks until all child tasks finish; they only finish when
+            // Task.isCancelled becomes true (via stop()).
+        }
+
+        // Dispatcher exit — return to idle. Triggered by stop() (or unrecoverable error).
+        self.state = .idle
+        self.statusMessage = "Idle"
+        logger.notice("[fg-sub] dispatcher exited; state=idle")
+    }
+
+    private func runRelayLoop(relayURL: String, userPubkey: String) async {
+        let conn = RelayConnection(url: relayURL)
+        var backoffSeconds: UInt64 = 1
+        let maxBackoff: UInt64 = 16
+
+        while !Task.isCancelled {
+            do {
+                try await conn.connect()
+                backoffSeconds = 1  // reset on successful connect
+
+                let foregroundStart = Date().timeIntervalSince1970
+                // 60s lookback so events published just before foregrounding
+                // (e.g., the auth_url-triggered burst) are caught.
+                let since = foregroundStart - 60
+                let subId = "fg-\(UUID().uuidString.prefix(8))".lowercased()
+                let filter: [String: Any] = [
+                    "kinds": [24133],
+                    "#p": [userPubkey],
+                    "since": Int(since)
+                ]
+                let reqArray: [Any] = ["REQ", subId, filter]
+                let reqData = try JSONSerialization.data(withJSONObject: reqArray)
+                let reqString = String(data: reqData, encoding: .utf8)!
+                try await conn.send(.string(reqString))
+
+                self.state = .listening
+                self.statusMessage = "Listening on \(relayURL)"
+                logger.notice("[fg-sub] subscribed sub=\(subId, privacy: .public) relay=\(relayURL, privacy: .public)")
+
+                // Concurrent: receive loop + heartbeat. Whichever throws first
+                // bubbles up and triggers a reconnect.
+                try await withThrowingTaskGroup(of: Void.self) { inner in
+                    inner.addTask { [self] in
+                        try await self.receiveLoop(conn: conn, subId: subId, userPubkey: userPubkey)
+                    }
+                    inner.addTask { [self] in
+                        try await self.heartbeatLoop(conn: conn)
+                    }
+                    _ = try await inner.next()
+                    inner.cancelAll()
+                }
+            } catch {
+                if Task.isCancelled { break }
+                let msg = "relay=\(relayURL) error: \(error.localizedDescription)"
+                logger.error("[fg-sub] \(msg, privacy: .public)")
+                self.lastError = msg
+                self.state = .reconnecting
+                self.statusMessage = "Reconnecting in \(backoffSeconds)s…"
+
+                try? await Task.sleep(nanoseconds: backoffSeconds * 1_000_000_000)
+                backoffSeconds = min(backoffSeconds * 2, maxBackoff)
+                await conn.disconnect()
+            }
+        }
+
+        await conn.disconnect()
+        logger.notice("[fg-sub] runRelayLoop(\(relayURL, privacy: .public)) exited")
+    }
+
+    // MARK: - Receive loop (event dispatch wired in Task 6)
+
+    private func receiveLoop(
+        conn: RelayConnection,
+        subId: String,
+        userPubkey: String
+    ) async throws {
+        while !Task.isCancelled {
+            let message = try await conn.receive()
+
+            guard case .string(let text) = message,
+                  let data = text.data(using: .utf8),
+                  let array = try? JSONSerialization.jsonObject(with: data) as? [Any],
+                  let type = array.first as? String else { continue }
+
+            switch type {
+            case "EVENT":
+                guard array.count >= 3,
+                      let eventSubId = array[1] as? String, eventSubId == subId,
+                      let _ = array[2] as? [String: Any] else { continue }
+
+                self.eventsReceived += 1
+                // TODO(Task 6): per-event dispatch goes here. For now we just
+                // count receipts so the connection + REQ + receive plumbing
+                // can be smoke-tested in isolation.
+
+            case "EOSE":
+                logger.notice("[fg-sub] EOSE — staying subscribed")
+            case "NOTICE":
+                let notice = (array.count >= 2 ? array[1] as? String : nil) ?? ""
+                logger.notice("[fg-sub] NOTICE: \(notice, privacy: .public)")
+            case "CLOSED":
+                let reason = (array.count >= 3 ? array[2] as? String : nil) ?? "(no reason)"
+                throw RelayConnectionError.subscriptionClosed(reason)
+            default:
+                continue
+            }
+        }
+    }
+
+    private func heartbeatLoop(conn: RelayConnection) async throws {
+        while !Task.isCancelled {
+            try await Task.sleep(nanoseconds: 30_000_000_000)  // 30s
+            try await conn.ping()
+        }
+    }
+}
+
+// MARK: - Per-relay WebSocket connection (actor-isolated)
+
+/// Wraps a single `URLSessionWebSocketTask` with actor-isolated send/receive/ping.
+/// Lifetime is one connect/disconnect cycle; reconnect creates a fresh socket
+/// inside the same actor by calling connect() again.
+private actor RelayConnection {
+    let url: String
+    private var task: URLSessionWebSocketTask?
+    private var session: URLSession?
+
+    init(url: String) { self.url = url }
+
+    func connect() async throws {
+        guard let urlObj = URL(string: url) else {
+            throw RelayConnectionError.invalidURL(url)
+        }
+        // Fresh URLSession per connect so we don't reuse a poisoned one.
+        let session = URLSession(configuration: .default)
+        self.session = session
+        let ws = session.webSocketTask(with: urlObj)
+        ws.resume()
+        self.task = ws
+
+        // Verify the connection is up via a ping. If the server is unreachable
+        // or the URL is bad, sendPing's callback fires with an error.
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            // Guard against double-resume (URLSessionWebSocketTask sometimes
+            // calls callbacks multiple times on cancel-after-pong).
+            let lock = NSLock()
+            var fired = false
+            ws.sendPing { error in
+                lock.lock(); defer { lock.unlock() }
+                if fired { return }
+                fired = true
+                if let error = error { cont.resume(throwing: error) }
+                else { cont.resume() }
+            }
+        }
+    }
+
+    func send(_ message: URLSessionWebSocketTask.Message) async throws {
+        guard let task = task else { throw RelayConnectionError.notConnected }
+        try await task.send(message)
+    }
+
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        guard let task = task else { throw RelayConnectionError.notConnected }
+        return try await task.receive()
+    }
+
+    func ping() async throws {
+        guard let task = task else { throw RelayConnectionError.notConnected }
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            let lock = NSLock()
+            var fired = false
+            task.sendPing { error in
+                lock.lock(); defer { lock.unlock() }
+                if fired { return }
+                fired = true
+                if let error = error { cont.resume(throwing: error) }
+                else { cont.resume() }
+            }
+        }
+    }
+
+    func disconnect() async {
+        task?.cancel(with: .normalClosure, reason: nil)
+        task = nil
+        session?.invalidateAndCancel()
+        session = nil
+    }
+}
+
+private enum RelayConnectionError: LocalizedError {
+    case invalidURL(String)
+    case notConnected
+    case subscriptionClosed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL(let u): return "Invalid relay URL: \(u)"
+        case .notConnected: return "Not connected to relay"
+        case .subscriptionClosed(let r): return "Relay closed subscription: \(r)"
         }
     }
 }

--- a/Shared/ForegroundRelaySubscription.swift
+++ b/Shared/ForegroundRelaySubscription.swift
@@ -163,11 +163,6 @@ final class ForegroundRelaySubscription {
 
     /// Returns the union of relayUrls across paired clients, plus the primary
     /// bunker relay as a guaranteed fallback. De-duplicated.
-    ///
-    /// In DEBUG builds, also includes any developer-set test relay (see
-    /// `SharedStorage.getDebugTestRelay`). Used during L1 verification matrix
-    /// when the harness publishes to a non-production relay (e.g. nak serve
-    /// on the developer's Mac LAN).
     private func relaySet() -> [String] {
         var set = Set<String>()
         set.insert(SharedConstants.relayURL)
@@ -176,11 +171,6 @@ final class ForegroundRelaySubscription {
                 set.insert(url)
             }
         }
-        #if DEBUG
-        if let debugRelay = SharedStorage.getDebugTestRelay(), !debugRelay.isEmpty {
-            set.insert(debugRelay)
-        }
-        #endif
         return Array(set)
     }
 

--- a/Shared/ForegroundRelaySubscription.swift
+++ b/Shared/ForegroundRelaySubscription.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Observation
+import os.log
+
+/// Foreground RPC accelerator. While Clave's main app is in the foreground,
+/// holds open WebSocket subscriptions to the user's relays and processes
+/// incoming kind:24133 NIP-46 RPCs inline via `LightSigner.handleRequest`,
+/// bypassing APNs+NSE for ~10× per-RPC speedup.
+///
+/// **`@MainActor` is the first introduction in Clave.** A grep across `Shared/`
+/// and `Clave/` confirms zero existing uses. Chosen because this class owns
+/// `@Observable` properties driving SwiftUI bindings (status indicators,
+/// progress UI in Layer 2); MainActor isolation simplifies those bindings
+/// without manual main-thread hops. The cost is contained — callers from
+/// non-isolated contexts (e.g. `AppState`) hop in via `Task { @MainActor in ... }`.
+///
+/// See spec: `~/hq/clave/specs/2026-04-26-foreground-bulk-decrypt-design.md`
+/// (Layer 1 section). Empirical justification:
+/// `~/hq/clave/research/nip17-bulk-decrypt/FINDINGS.md`.
+///
+/// Layer 2 (bulk decrypt session UX, conversation-key cache, auth_url
+/// heuristic) builds on top of this class without modifying it. L1 is shipped
+/// standalone first so users get the "Clave is snappier when open" benefit
+/// before any L2 UX exists.
+
+private let logger = Logger(subsystem: "dev.nostr.clave", category: "fg-sub")
+
+@Observable
+@MainActor
+final class ForegroundRelaySubscription {
+    static let shared = ForegroundRelaySubscription()
+
+    // MARK: - State
+
+    enum State: String {
+        case idle
+        case starting
+        case listening
+        case reconnecting
+        case stopping
+        case error
+    }
+
+    private(set) var state: State = .idle
+    private(set) var statusMessage: String = "Idle"
+    private(set) var eventsReceived: Int = 0
+    private(set) var eventsProcessed: Int = 0
+    private(set) var eventsFailed: Int = 0
+    private(set) var lastError: String?
+
+    /// Ring buffer of last 1024 latencies (ms). Layer 2's progress UI reads this.
+    private(set) var recentLatenciesMs: [Double] = []
+    private static let latencyRingCap = 1024
+
+    // MARK: - Internals (filled in subsequent tasks)
+
+    private var dispatcherTask: Task<Void, Never>?
+
+    private init() {}
+
+    // MARK: - Public API
+
+    func start() {
+        guard state == .idle || state == .error else { return }
+        state = .starting
+        statusMessage = "Connecting…"
+        // TODO(Task 5): spawn dispatcher Task that runs withTaskGroup
+        // over the relay set and processes incoming kind:24133 events.
+        logger.notice("[fg-sub] start() called (skeleton — no-op until Task 5)")
+    }
+
+    func stop() {
+        guard state != .idle else { return }
+        state = .stopping
+        dispatcherTask?.cancel()
+        dispatcherTask = nil
+        state = .idle
+        statusMessage = "Idle"
+        logger.notice("[fg-sub] stop() called")
+    }
+
+    func resetCounters() {
+        eventsReceived = 0
+        eventsProcessed = 0
+        eventsFailed = 0
+        recentLatenciesMs.removeAll(keepingCapacity: true)
+        lastError = nil
+    }
+
+    // MARK: - Latency tracking
+
+    fileprivate func recordLatency(_ ms: Double) {
+        recentLatenciesMs.append(ms)
+        if recentLatenciesMs.count > Self.latencyRingCap {
+            recentLatenciesMs.removeFirst(recentLatenciesMs.count - Self.latencyRingCap)
+        }
+    }
+}

--- a/Shared/ForegroundRelaySubscription.swift
+++ b/Shared/ForegroundRelaySubscription.swift
@@ -65,6 +65,10 @@ final class ForegroundRelaySubscription {
     /// invocation; if the publish path hangs, we cancel and free the slot.
     static let perEventBudgetSeconds: UInt64 = 30
 
+    /// Concurrency cap. Backpressure point that prevents the receive loop
+    /// from outrunning the dispatcher under bursts.
+    private let dispatchSemaphore = AsyncSemaphore(Self.defaultConcurrency)
+
     private init() {}
 
     // MARK: - Public API
@@ -246,12 +250,17 @@ final class ForegroundRelaySubscription {
             case "EVENT":
                 guard array.count >= 3,
                       let eventSubId = array[1] as? String, eventSubId == subId,
-                      let _ = array[2] as? [String: Any] else { continue }
+                      let eventDict = array[2] as? [String: Any] else { continue }
 
                 self.eventsReceived += 1
-                // TODO(Task 6): per-event dispatch goes here. For now we just
-                // count receipts so the connection + REQ + receive plumbing
-                // can be smoke-tested in isolation.
+
+                // Backpressure: receive loop awaits a permit before spawning the
+                // per-event task. Five permits is the FINDINGS.md sweet spot.
+                await dispatchSemaphore.acquire()
+                Task { [self] in
+                    defer { Task { await self.dispatchSemaphore.release() } }
+                    await self.processEvent(eventDict, relayURL: conn.url)
+                }
 
             case "EOSE":
                 logger.notice("[fg-sub] EOSE — staying subscribed")
@@ -271,6 +280,101 @@ final class ForegroundRelaySubscription {
         while !Task.isCancelled {
             try await Task.sleep(nanoseconds: 30_000_000_000)  // 30s
             try await conn.ping()
+        }
+    }
+
+    // MARK: - Per-event dispatch
+
+    /// Dispatches a single kind:24133 event through `LightSigner.handleRequest`
+    /// with a per-event 30s budget. Updates counters + latency ring buffer.
+    /// Runs off the MainActor inside a Task spawned by the receive loop.
+    private nonisolated func processEvent(
+        _ eventDict: [String: Any],
+        relayURL: String
+    ) async {
+        guard let nsec = SharedKeychain.loadNsec(),
+              let privateKey = try? Bech32.decodeNsec(nsec) else {
+            await MainActor.run {
+                self.lastError = "Failed to load signer key"
+                self.eventsFailed += 1
+            }
+            return
+        }
+
+        let started = Date()
+
+        // 30s budget enforced via withTaskGroup race: the work task vs.
+        // a sleep-then-cancel watchdog. First to complete wins; the other
+        // is cancelled by the group.
+        let result: LightSigner.RequestResult? = await withTaskGroup(
+            of: LightSigner.RequestResult?.self
+        ) { group in
+            group.addTask {
+                do {
+                    return try await LightSigner.handleRequest(
+                        privateKey: privateKey,
+                        requestEvent: eventDict,
+                        skipProtection: false,
+                        responseRelayUrl: relayURL
+                    )
+                } catch {
+                    return nil
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: Self.perEventBudgetSeconds * 1_000_000_000)
+                return nil  // timeout sentinel
+            }
+
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first ?? nil
+        }
+
+        let elapsedMs = Date().timeIntervalSince(started) * 1000
+
+        await MainActor.run {
+            // "signed" — completed normally. "skipped-duplicate" — already
+            // handled by NSE or another path. Both count as processed.
+            // Other statuses (error/blocked/pending) count as failed for
+            // L1 telemetry; protected-kind queue prompts go via the
+            // existing path and don't appear here.
+            if let result = result, result.status == "signed" || result.status == "skipped-duplicate" {
+                self.eventsProcessed += 1
+            } else {
+                self.eventsFailed += 1
+            }
+            self.recordLatency(elapsedMs)
+        }
+    }
+}
+
+// MARK: - Async semaphore for receive-loop backpressure
+
+/// Simple actor-isolated counting semaphore. `acquire()` waits if the permit
+/// count is zero; `release()` resumes the next waiter or restores a permit.
+private actor AsyncSemaphore {
+    private var permits: Int
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(_ initial: Int) { self.permits = initial }
+
+    func acquire() async {
+        if permits > 0 {
+            permits -= 1
+            return
+        }
+        await withCheckedContinuation { cont in
+            waiters.append(cont)
+        }
+    }
+
+    func release() {
+        if !waiters.isEmpty {
+            let next = waiters.removeFirst()
+            next.resume()
+        } else {
+            permits += 1
         }
     }
 }

--- a/Shared/ForegroundRelaySubscription.swift
+++ b/Shared/ForegroundRelaySubscription.swift
@@ -126,6 +126,24 @@ final class ForegroundRelaySubscription {
         lastError = nil
     }
 
+    /// Recompute the relay set from current `ConnectedClient.relayUrls` and
+    /// reconcile the running dispatcher: connect to newly-added relays,
+    /// disconnect from removed ones. Idempotent; safe to call any number of
+    /// times.
+    ///
+    /// v1 implementation: stop and restart. The ~100ms reconnect bounce is
+    /// acceptable given pair/unpair are infrequent operations. Proper
+    /// add/remove diffing is a follow-up; see plan Task 8 risks.
+    func refreshRelaySet() {
+        guard state == .listening || state == .reconnecting else { return }
+        logger.notice("[fg-sub] refreshRelaySet: stop+restart")
+        stop()
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 100_000_000)  // 100ms
+            self?.start()
+        }
+    }
+
     // MARK: - Latency tracking
 
     fileprivate func recordLatency(_ ms: Double) {

--- a/Shared/ForegroundRelaySubscription.swift
+++ b/Shared/ForegroundRelaySubscription.swift
@@ -67,7 +67,7 @@ final class ForegroundRelaySubscription {
 
     /// Concurrency cap. Backpressure point that prevents the receive loop
     /// from outrunning the dispatcher under bursts.
-    private let dispatchSemaphore = AsyncSemaphore(Self.defaultConcurrency)
+    private let dispatchSemaphore = AsyncSemaphore(ForegroundRelaySubscription.defaultConcurrency)
 
     private init() {}
 

--- a/Shared/ForegroundRelaySubscription.swift
+++ b/Shared/ForegroundRelaySubscription.swift
@@ -112,10 +112,16 @@ final class ForegroundRelaySubscription {
     func stop() {
         guard state != .idle else { return }
         logger.notice("[fg-sub] stop() called from state=\(self.state.rawValue, privacy: .public)")
-        state = .stopping
+        // Cancel the dispatcher and transition to idle synchronously. The
+        // dispatcher exits asynchronously at its next suspension point —
+        // when it does, runDispatcher's tail logic re-asserts state=.idle
+        // (no-op). Setting .idle here keeps the public state machine
+        // observable-consistent: callers see .idle immediately after stop()
+        // returns, regardless of how slowly the dispatcher unwinds.
         dispatcherTask?.cancel()
         dispatcherTask = nil
-        // dispatcher exits inside runDispatcher() which transitions back to .idle
+        state = .idle
+        statusMessage = "Idle"
     }
 
     func resetCounters() {

--- a/Shared/ForegroundRelaySubscription.swift
+++ b/Shared/ForegroundRelaySubscription.swift
@@ -163,6 +163,11 @@ final class ForegroundRelaySubscription {
 
     /// Returns the union of relayUrls across paired clients, plus the primary
     /// bunker relay as a guaranteed fallback. De-duplicated.
+    ///
+    /// In DEBUG builds, also includes any developer-set test relay (see
+    /// `SharedStorage.getDebugTestRelay`). Used during L1 verification matrix
+    /// when the harness publishes to a non-production relay (e.g. nak serve
+    /// on the developer's Mac LAN).
     private func relaySet() -> [String] {
         var set = Set<String>()
         set.insert(SharedConstants.relayURL)
@@ -171,6 +176,11 @@ final class ForegroundRelaySubscription {
                 set.insert(url)
             }
         }
+        #if DEBUG
+        if let debugRelay = SharedStorage.getDebugTestRelay(), !debugRelay.isEmpty {
+            set.insert(debugRelay)
+        }
+        #endif
         return Array(set)
     }
 

--- a/Shared/LightSigner.swift
+++ b/Shared/LightSigner.swift
@@ -27,6 +27,26 @@ enum LightSigner {
                                  status: "error", errorMessage: "Invalid event")
         }
 
+        // Per-event-id dedupe (audit D.1.1). Both NSE and the foreground
+        // relay subscription (Layer 1) call into this function; whichever
+        // marks first wins, others skip. Cross-process semantics are lossy
+        // by design — see SharedStorage.markEventProcessed.
+        let eventId = (requestEvent["id"] as? String) ?? ""
+        let createdAt = (requestEvent["created_at"] as? Double)
+            ?? Double(requestEvent["created_at"] as? Int ?? 0)
+        let nowFallback = Date().timeIntervalSince1970
+        if !eventId.isEmpty,
+           SharedStorage.markEventProcessed(
+               eventId: eventId,
+               createdAt: createdAt > 0 ? createdAt : nowFallback
+           ) == .alreadyProcessed {
+            logger.notice("[LightSigner] skip dedup eid=\(eventId.prefix(8), privacy: .public)")
+            return RequestResult(
+                method: "deduped", eventKind: nil, clientPubkey: senderPubkey,
+                status: "skipped-duplicate", errorMessage: nil
+            )
+        }
+
         guard let senderPubkeyData = Data(hexString: senderPubkey) else {
             logger.error("[LightSigner] Invalid sender pubkey hex")
             return RequestResult(method: "unknown", eventKind: nil, clientPubkey: senderPubkey,

--- a/Shared/SharedStorage.swift
+++ b/Shared/SharedStorage.swift
@@ -58,6 +58,35 @@ enum SharedStorage {
         }
     }
 
+    /// Persist the client's URI relay set locally. Mirrors the `/pair-client`
+    /// payload that already gets sent to the proxy. Used by Layer 1's
+    /// foreground subscription to build its target relay set.
+    /// (Pre-L1 the field existed in `ConnectedClient` but was never
+    /// populated — fixed here.)
+    static func setClientRelayUrls(pubkey: String, relayUrls: [String]) {
+        var clients = getConnectedClients()
+        let cleaned = relayUrls.filter { !$0.isEmpty }
+        if let idx = clients.firstIndex(where: { $0.pubkey == pubkey }) {
+            clients[idx].relayUrls = cleaned
+            save(clients, forKey: SharedConstants.connectedClientsKey)
+            logger.notice("[Storage] setClientRelayUrls: \(pubkey.prefix(8), privacy: .public) count=\(cleaned.count)")
+        } else {
+            // Client not yet known — create the entry so the relays are persisted.
+            // updateClient will be called separately when the first request comes in.
+            let now = Date().timeIntervalSince1970
+            clients.append(ConnectedClient(
+                pubkey: pubkey,
+                name: nil,
+                firstSeen: now,
+                lastSeen: now,
+                requestCount: 0,
+                relayUrls: cleaned
+            ))
+            save(clients, forKey: SharedConstants.connectedClientsKey)
+            logger.notice("[Storage] setClientRelayUrls (new client): \(pubkey.prefix(8), privacy: .public) count=\(cleaned.count)")
+        }
+    }
+
     static func getConnectedClients() -> [ConnectedClient] {
         load(forKey: SharedConstants.connectedClientsKey) ?? []
     }

--- a/Shared/SharedStorage.swift
+++ b/Shared/SharedStorage.swift
@@ -252,6 +252,76 @@ enum SharedStorage {
         saveClientPermissions(perms)
     }
 
+    // MARK: - Per-event-id dedupe (cross-process via app-group UserDefaults)
+    //
+    // Used by LightSigner.handleRequest to short-circuit duplicate processing
+    // when both NSE and the foreground app's WebSocket sub catch the same event.
+    //
+    // Lossy semantics across processes are acceptable: occasional double-publish
+    // is harmless because NIP-46 clients dedupe responses by `id`. Within one
+    // process, the lock ensures atomic check-and-insert.
+    //
+    // Audit D.1.1: insertion-ordered ring buffer (200 entries) + age bound
+    // (60s based on event.created_at). Replaces the prior Set + .suffix(50)
+    // logic that was duplicated inline in Clave/ClaveApp.swift and
+    // ClaveNSE/NotificationService.swift; those call sites are removed once
+    // LightSigner becomes the single dedupe choke point.
+
+    enum ProcessedStatus { case markedNew, alreadyProcessed }
+
+    private static let processedEventIDsCap = 200
+    private static let processedEventIDsAgeWindow: Double = 60  // seconds
+
+    #if DEBUG
+    nonisolated(unsafe) private static var processedEventIDsKeyOverride: String?
+    static func _setProcessedEventIDsKeyForTesting(_ key: String) { processedEventIDsKeyOverride = key }
+    static func _resetProcessedEventIDsKeyForTesting() { processedEventIDsKeyOverride = nil }
+    #endif
+
+    private static var processedEventIDsKey: String {
+        #if DEBUG
+        return processedEventIDsKeyOverride ?? "processedEventIDs"
+        #else
+        return "processedEventIDs"
+        #endif
+    }
+
+    private static let processedEventIDsLock = NSLock()  // intra-process only
+
+    /// Stored format: array of `"<eventId>:<createdAt>"` strings, insertion order
+    /// preserved by Array semantics. Cross-process races may produce duplicate
+    /// inserts; NIP-46 client-side id-match handles the resulting double-response.
+    static func markEventProcessed(eventId: String, createdAt: Double) -> ProcessedStatus {
+        processedEventIDsLock.lock()
+        defer { processedEventIDsLock.unlock() }
+
+        let now = Date().timeIntervalSince1970
+        var entries = defaults.stringArray(forKey: processedEventIDsKey) ?? []
+
+        // Age-based eviction sweep on every call (cheap — bounded list).
+        entries = entries.filter { entry in
+            let parts = entry.split(separator: ":", maxSplits: 1).map(String.init)
+            guard parts.count == 2, let ts = Double(parts[1]) else { return false }
+            return (now - ts) <= processedEventIDsAgeWindow
+        }
+
+        // Check if eventId already present.
+        let prefix = "\(eventId):"
+        if entries.contains(where: { $0.hasPrefix(prefix) }) {
+            // Refresh storage with the post-eviction list (may have changed).
+            defaults.set(entries, forKey: processedEventIDsKey)
+            return .alreadyProcessed
+        }
+
+        // Insert.
+        entries.append("\(eventId):\(createdAt)")
+        if entries.count > processedEventIDsCap {
+            entries.removeFirst(entries.count - processedEventIDsCap)
+        }
+        defaults.set(entries, forKey: processedEventIDsKey)
+        return .markedNew
+    }
+
     // MARK: - Helpers
 
     private static func save<T: Encodable>(_ value: T, forKey key: String) {

--- a/Shared/SharedStorage.swift
+++ b/Shared/SharedStorage.swift
@@ -91,29 +91,6 @@ enum SharedStorage {
         load(forKey: SharedConstants.connectedClientsKey) ?? []
     }
 
-    #if DEBUG
-    /// DEBUG-only L1 verification override. Lets a developer point Layer 1's
-    /// foreground subscription at an arbitrary test relay (e.g. `nak serve`
-    /// on Mac LAN) without going through a fresh nostrconnect pair. Not
-    /// compiled in Release builds.
-    private static let debugTestRelayKey = "debug.l1TestRelay"
-
-    static func getDebugTestRelay() -> String? {
-        let v = defaults.string(forKey: debugTestRelayKey) ?? ""
-        return v.isEmpty ? nil : v
-    }
-
-    static func setDebugTestRelay(_ url: String?) {
-        if let url = url, !url.isEmpty {
-            defaults.set(url, forKey: debugTestRelayKey)
-            logger.notice("[Storage] setDebugTestRelay: \(url, privacy: .public)")
-        } else {
-            defaults.removeObject(forKey: debugTestRelayKey)
-            logger.notice("[Storage] setDebugTestRelay: cleared")
-        }
-    }
-    #endif
-
     // MARK: - Pending Requests
 
     static func queuePendingRequest(_ request: PendingRequest) {

--- a/Shared/SharedStorage.swift
+++ b/Shared/SharedStorage.swift
@@ -91,6 +91,29 @@ enum SharedStorage {
         load(forKey: SharedConstants.connectedClientsKey) ?? []
     }
 
+    #if DEBUG
+    /// DEBUG-only L1 verification override. Lets a developer point Layer 1's
+    /// foreground subscription at an arbitrary test relay (e.g. `nak serve`
+    /// on Mac LAN) without going through a fresh nostrconnect pair. Not
+    /// compiled in Release builds.
+    private static let debugTestRelayKey = "debug.l1TestRelay"
+
+    static func getDebugTestRelay() -> String? {
+        let v = defaults.string(forKey: debugTestRelayKey) ?? ""
+        return v.isEmpty ? nil : v
+    }
+
+    static func setDebugTestRelay(_ url: String?) {
+        if let url = url, !url.isEmpty {
+            defaults.set(url, forKey: debugTestRelayKey)
+            logger.notice("[Storage] setDebugTestRelay: \(url, privacy: .public)")
+        } else {
+            defaults.removeObject(forKey: debugTestRelayKey)
+            logger.notice("[Storage] setDebugTestRelay: cleared")
+        }
+    }
+    #endif
+
     // MARK: - Pending Requests
 
     static func queuePendingRequest(_ request: PendingRequest) {


### PR DESCRIPTION
## Summary

Adds Layer 1 of the foreground RPC acceleration design — an `@MainActor`-isolated `ForegroundRelaySubscription` that holds long-lived WebSocket subscriptions to the user's relays whenever Clave is foregrounded, processing kind:24133 NIP-46 RPCs inline via `LightSigner.handleRequest()` instead of waiting on APNs+NSE.

Also closes audit item D.1.1 by consolidating the duplicate inline `processedEventIDs` dedupe logic from `ClaveApp.swift` and `NotificationService.swift` into a single `SharedStorage.markEventProcessed()` helper with insertion-ordered ring buffer + 60s age bound.

## Why

Empirical: bunker mode (APNs+NSE) caps at ~1.6 dec/sec; foreground subscription hits **40.46 dec/sec at conc=5** (verified on real device against `nak serve`). For the dev's 7000-DM scenario, that's **~5.8 minutes vs 2.4 hours** = ~25× speedup. Justifies the structural change and produces a markedly snappier in-app experience for any NIP-46 client (Wisp, Nostur, Coracle, etc.) — no client-side changes required.

## What's in this PR

### Production code
- `Shared/ForegroundRelaySubscription.swift` (new, ~370 lines): `@MainActor @Observable` class. Per-relay `URLSessionWebSocketTask` actors. `withTaskGroup`-based dispatcher matching existing AppState/LightSigner concurrency patterns. Heartbeat (30s ping / 10s pong timeout), exponential reconnect backoff (1/2/4/8/16s). `AsyncSemaphore` for per-event concurrency cap (default 5, the empirical sweet spot from FINDINGS). 30s per-event budget enforced via `withTaskGroup` race against a sleep watchdog. Receive loop dispatches events to `LightSigner.handleRequest` with `responseRelayUrl` threaded back to the originating relay.
- `Shared/SharedStorage.swift`: new `markEventProcessed(eventId:, createdAt:)` helper + new `setClientRelayUrls()` / `getDebugTestRelay()` / `setDebugTestRelay()` helpers. The dedupe helper is the single choke point both NSE and L1 inherit; the relayUrls setter populates `ConnectedClient.relayUrls` at pair time (it was a dead field added in PR #9 V2 but never written by any code path until this PR).
- `Shared/LightSigner.swift`: dedupe check at the top of `handleRequest` via `markEventProcessed`. Returns `skipped-duplicate` status when the event was already processed by another path.
- `Clave/ClaveApp.swift` + `ClaveNSE/NotificationService.swift`: removed redundant inline dedupe blocks (now handled in LightSigner). Net deletion of ~95 lines of duplicated logic.
- `Clave/AppState.swift`: `startForegroundSubscription` / `stopForegroundSubscription` `@MainActor` bridge methods. `pairClientWithProxy` now also calls `setClientRelayUrls` and triggers `refreshRelaySet()`. `unpairClientWithProxy` triggers `refreshRelaySet()`.
- `Clave/Views/MainTabView.swift`: scenePhase observer with 2s `.inactive` grace (cancels pending stop on app-switcher peek / control-center swipe). Confirmed background stops immediately.
- `Clave/Info.plist`: `NSAllowsLocalNetworking` ATS exception so the new WebSocket sub can connect to plain `ws://` hosts on the local network for dev verification (production traffic still uses `wss://relay.powr.build`).

### Tests
- `ClaveTests/SharedStorageDedupTests.swift` (new, 5 tests): first-seen, repeat, ring buffer cap, age eviction, concurrent within-process serialization.
- `ClaveTests/ForegroundRelaySubscriptionTests.swift` (new, 5 tests): initial state, no-signer-key error path, resetCounters, stop-while-idle no-op, double-start idempotent.
- All existing tests still green.

### DEBUG-only test scaffolding (kept in `#if DEBUG`)
- `Settings → Developer → DEBUG: L1 Test Relay` section. Lets a developer add an extra relay to L1's subscription set without going through nostrconnect pairing. Used during the L1 verification matrix to point L1 at `nak serve` on Mac LAN. Status indicator + live counters (Received / Processed / Failed). Apply / Clear buttons (each in its own row to avoid SwiftUI's HStack-tap-target footgun).

Production builds (Release) compile **none** of this DEBUG section.

## Empirical evidence

`~/hq/clave/research/nip17-bulk-decrypt/FINDINGS.md` — full numbers, methodology, comparison tables. Headline:

| Path | Throughput @ conc=5 | p50 latency | p99 latency | Success |
|---|---:|---:|---:|---:|
| Clave bunker (today) | 1.61/s | 2409ms | 7805ms | 98.79% |
| L1 production (this PR) | **40.46/s** | **93ms** | **488ms** | **100%** |

## Test plan

- [x] Unit tests: SharedStorageDedupTests (5), ForegroundRelaySubscriptionTests (5)
- [x] Build clean: `xcodebuild -scheme Clave -configuration Debug` ⇒ BUILD SUCCEEDED
- [x] All existing tests still green
- [x] Manual matrix on device: 1000-RPC harness run against `nak serve`, throughput 40.46/s, success 100%
- [x] Backgrounding lifecycle: 2s grace verified; confirmed-background stops immediately
- [x] Audit D.1.1 closed (insertion-ordered ring buffer + age bound replaces `Set + .suffix(50)`)
- [ ] Internal TestFlight matrix (post-merge)
- [ ] Dual-path coexistence: foreground L1 + APNs both running, dedupe prevents double-processing — needs internal TestFlight (debug build uses sandbox APNs)
- [ ] External TestFlight (after internal pass)

## Spec / plan / prototype

- Design spec: `~/hq/clave/specs/2026-04-26-foreground-bulk-decrypt-design.md`
- Implementation plan: `~/hq/clave/plans/2026-04-26-foreground-relay-subscription.md`
- Prototype branch (research artifact, will be deleted after this lands): `feat/debug-foreground-subscription` (tag `research/fg-sub-prototype-2026-04-26`)

Layer 2 (bulk decrypt session UX, conversation-key cache, auth_url heuristic) is a separate follow-up sprint that builds on top of L1 without modifying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)