### PR TITLE
fix(proxy): GOAWAY-aware APNs client + auto-prune stale tokens

### DIFF
--- a/relay-proxy/apnsClient.js
+++ b/relay-proxy/apnsClient.js
@@ -1,0 +1,402 @@
+"use strict";
+
+/**
+ * APNs HTTP/2 client wrapper with GOAWAY-aware reconnection, single-retry
+ * on transient session errors, periodic health ping, and operational
+ * counters. Replaces the inline implementation that previously lived in
+ * proxy.js and silently went dead after Apple's GOAWAY frames.
+ *
+ * The previous implementation only nulled the cached session on its
+ * `error` and `close` events. Apple sends a GOAWAY frame to signal
+ * graceful close — after GOAWAY the session is NOT `destroyed`, just
+ * unable to create new streams. The check `if (apnsClient && !apnsClient.destroyed)`
+ * happily returned the dead session for every subsequent send. Result:
+ * ~6 hours of zero APNs delivery on 2026-04-27 evening.
+ *
+ * This module:
+ *  - Listens for the `goaway` event explicitly and discards the session.
+ *  - Detects per-request errors that imply the session is dead
+ *    (NGHTTP2_REFUSED_STREAM, ERR_HTTP2_GOAWAY_SESSION, ECONNRESET) and
+ *    automatically retries once on a fresh session.
+ *  - Sends an HTTP/2 PING every 5 minutes so the kernel + Apple both keep
+ *    the socket warm; if the ping fails the session is replaced before the
+ *    next real push.
+ *  - Exposes counters for `/health` so we can detect the "stuck dead"
+ *    state from outside the process next time.
+ */
+
+const http2 = require("http2");
+const crypto = require("crypto");
+const fs = require("fs");
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Errors that mean "this session is dead — replace it before the next send".
+ * Anything not in this set is treated as a transient per-request failure
+ * (timeout, malformed body, etc.) and does NOT invalidate the session.
+ */
+const FATAL_SESSION_CODES = new Set([
+  "ERR_HTTP2_GOAWAY_SESSION",
+  "ERR_HTTP2_INVALID_SESSION",
+  "ERR_HTTP2_STREAM_CANCEL",
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "EPIPE",
+  "ETIMEDOUT",
+]);
+
+const FATAL_NGHTTP2_CODES = new Set([
+  "NGHTTP2_REFUSED_STREAM",
+  "NGHTTP2_ENHANCE_YOUR_CALM",
+  "NGHTTP2_INTERNAL_ERROR",
+]);
+
+function isSessionFatalError(err) {
+  if (!err) return false;
+  if (err.code && FATAL_SESSION_CODES.has(err.code)) return true;
+  // node http2 surfaces nghttp2 codes in the message string for some errors.
+  const msg = String(err.message || "");
+  for (const code of FATAL_NGHTTP2_CODES) {
+    if (msg.includes(code)) return true;
+  }
+  if (msg.includes("GOAWAY")) return true;
+  return false;
+}
+
+/**
+ * Both 410 Unregistered and 400 BadDeviceToken mean "stop sending to this
+ * token". Apple's docs lump them together as terminal token states. The
+ * previous code only pruned on 410, leaving stale-from-reinstall tokens
+ * stuck forever (one user accumulated 199 BadDeviceToken responses in 24h
+ * before we noticed).
+ */
+function shouldPruneToken(status, body) {
+  if (status === 410) return true;
+  if (status === 400) {
+    const reason = parseReason(body);
+    if (reason === "BadDeviceToken" || reason === "DeviceTokenNotForTopic") {
+      return true;
+    }
+  }
+  return false;
+}
+
+function parseReason(body) {
+  if (!body) return null;
+  if (typeof body === "object") return body.reason || null;
+  try {
+    const parsed = JSON.parse(body);
+    return parsed.reason || null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JWT (ES256, cached for 50 min — Apple allows up to 60)
+// ---------------------------------------------------------------------------
+
+function derToRaw(derSig) {
+  if (derSig[0] !== 0x30) throw new Error("Invalid DER");
+  if (derSig[2] !== 0x02) throw new Error("Invalid DER");
+  const rLen = derSig[3];
+  const r = derSig.subarray(4, 4 + rLen);
+  let offset = 4 + rLen;
+  if (derSig[offset] !== 0x02) throw new Error("Invalid DER");
+  const sLen = derSig[offset + 1];
+  const s = derSig.subarray(offset + 2, offset + 2 + sLen);
+  const rPad = Buffer.alloc(32);
+  r.copy(rPad, Math.max(0, 32 - r.length), Math.max(0, r.length - 32));
+  const sPad = Buffer.alloc(32);
+  s.copy(sPad, Math.max(0, 32 - s.length), Math.max(0, s.length - 32));
+  return Buffer.concat([rPad, sPad]);
+}
+
+// ---------------------------------------------------------------------------
+// Client factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an APNs client.
+ *
+ * @param {object} opts
+ * @param {string} opts.host           - APNs host (e.g. "api.push.apple.com").
+ * @param {string} opts.topic          - APNs topic (bundle id).
+ * @param {string} opts.keyId          - APNs key id (header `kid`).
+ * @param {string} opts.teamId         - APNs team id (JWT `iss`).
+ * @param {string} opts.keyPath        - Path to .p8 file.
+ * @param {object} [opts.logger=console]
+ * @param {number} [opts.pingIntervalMs=300000] - 5 min default.
+ *                                                Set to 0 to disable.
+ */
+function createApnsClient(opts) {
+  const {
+    host,
+    topic,
+    keyId,
+    teamId,
+    keyPath,
+    logger = console,
+    pingIntervalMs = 300_000,
+  } = opts;
+
+  if (!host || !topic || !keyId || !teamId || !keyPath) {
+    throw new Error("createApnsClient: missing required options");
+  }
+
+  let session = null;
+  let sessionConnectedAt = 0;
+  let pingTimer = null;
+
+  let cachedJwt = null;
+  let cachedJwtTime = 0;
+
+  // Operational counters surfaced via /health.
+  const stats = {
+    sessionConnects: 0,
+    sessionInvalidations: 0,
+    sendOk: 0,
+    sendFail: 0,
+    sendRetried: 0,
+    pruneOnBadDeviceToken: 0,
+    pruneOnUnregistered: 0,
+    lastSendAt: null,
+    lastFailureAt: null,
+    lastFailureReason: null,
+  };
+
+  function makeJwt() {
+    const now = Math.floor(Date.now() / 1000);
+    if (cachedJwt && now - cachedJwtTime < 3000) return cachedJwt;
+    const key = fs.readFileSync(keyPath, "utf8");
+    const header = Buffer.from(
+      JSON.stringify({ alg: "ES256", kid: keyId })
+    ).toString("base64url");
+    const payload = Buffer.from(
+      JSON.stringify({ iss: teamId, iat: now })
+    ).toString("base64url");
+    const sigInput = `${header}.${payload}`;
+    const signer = crypto.createSign("SHA256");
+    signer.update(sigInput);
+    const sig = signer.sign(key);
+    const raw = derToRaw(sig);
+    cachedJwt = `${header}.${payload}.${raw.toString("base64url")}`;
+    cachedJwtTime = now;
+    return cachedJwt;
+  }
+
+  function clearPingTimer() {
+    if (pingTimer) {
+      clearInterval(pingTimer);
+      pingTimer = null;
+    }
+  }
+
+  function invalidateSession(reason) {
+    if (!session) return;
+    stats.sessionInvalidations += 1;
+    logger.warn(`[APNs] Invalidating session (${reason})`);
+    clearPingTimer();
+    try {
+      session.close();
+    } catch {
+      // best-effort; session may already be gone
+    }
+    session = null;
+    sessionConnectedAt = 0;
+  }
+
+  function startPingTimer() {
+    if (pingIntervalMs <= 0) return;
+    clearPingTimer();
+    pingTimer = setInterval(() => {
+      if (!session || session.destroyed || session.closed) {
+        clearPingTimer();
+        return;
+      }
+      try {
+        session.ping((err) => {
+          if (err) {
+            logger.warn(`[APNs] Ping failed: ${err.message}`);
+            invalidateSession("ping-failed");
+          }
+        });
+      } catch (err) {
+        logger.warn(`[APNs] Ping threw: ${err.message}`);
+        invalidateSession("ping-threw");
+      }
+    }, pingIntervalMs);
+    // Don't keep the event loop alive just for this timer.
+    if (typeof pingTimer.unref === "function") pingTimer.unref();
+  }
+
+  function getSession() {
+    if (session && !session.destroyed && !session.closed) return session;
+    session = http2.connect(`https://${host}`);
+    sessionConnectedAt = Date.now();
+    stats.sessionConnects += 1;
+
+    session.on("error", (err) => {
+      logger.error(`[APNs] Session error: ${err.message}`);
+      invalidateSession("error-event");
+    });
+    session.on("close", () => {
+      // close fires on both graceful and forced; null out so the next
+      // request creates a new session.
+      session = null;
+      sessionConnectedAt = 0;
+      clearPingTimer();
+    });
+    // GOAWAY: Apple is asking us to stop using this session for new
+    // streams. The session itself stays alive briefly for in-flight
+    // streams, but we must not start any new ones. Discard immediately
+    // so the very next sendPush opens a fresh session.
+    session.on("goaway", (errorCode, lastStreamID) => {
+      logger.warn(
+        `[APNs] GOAWAY received (errorCode=${errorCode}, lastStreamID=${lastStreamID})`
+      );
+      invalidateSession("goaway");
+    });
+    session.on("frameError", (type, code, id) => {
+      logger.warn(
+        `[APNs] frameError (type=${type}, code=${code}, streamId=${id})`
+      );
+      invalidateSession("frameError");
+    });
+
+    startPingTimer();
+    return session;
+  }
+
+  function sendOnce(client, token, jwt, body) {
+    return new Promise((resolve, reject) => {
+      let req;
+      try {
+        req = client.request({
+          ":method": "POST",
+          ":path": `/3/device/${token}`,
+          authorization: `bearer ${jwt}`,
+          "apns-topic": topic,
+          "apns-push-type": "alert",
+          "apns-priority": "10",
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body),
+        });
+      } catch (err) {
+        // Synchronous throws (e.g. session destroyed mid-call) need to be
+        // caught — otherwise they bubble up as uncaught and crash the
+        // dispatcher loop.
+        return reject(err);
+      }
+
+      let data = "";
+      req.on("response", (headers) => {
+        const status = headers[":status"];
+        req.on("data", (d) => (data += d));
+        req.on("end", () => {
+          resolve({ status, body: data });
+        });
+      });
+      req.on("error", reject);
+      try {
+        req.write(body);
+        req.end();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+
+  /**
+   * Send a single push. Auto-retries once on session-fatal errors with a
+   * fresh session.
+   *
+   * @returns {Promise<{status:number, body:string, retried:boolean}>}
+   */
+  async function sendPush(token, payload) {
+    const jwt = makeJwt();
+    const body = JSON.stringify(payload);
+
+    let attempt = 0;
+    let lastError = null;
+    while (attempt < 2) {
+      const client = getSession();
+      try {
+        const result = await sendOnce(client, token, jwt, body);
+        stats.sendOk += 1;
+        stats.lastSendAt = new Date().toISOString();
+        return { ...result, retried: attempt > 0 };
+      } catch (err) {
+        lastError = err;
+        if (isSessionFatalError(err) && attempt === 0) {
+          logger.warn(
+            `[APNs] Session-fatal error on attempt 1 (${err.message}) — retrying on fresh session`
+          );
+          stats.sendRetried += 1;
+          invalidateSession("send-fatal");
+          attempt += 1;
+          continue;
+        }
+        stats.sendFail += 1;
+        stats.lastFailureAt = new Date().toISOString();
+        stats.lastFailureReason = err.message;
+        throw err;
+      }
+    }
+    // Unreachable but keeps tooling honest.
+    throw lastError || new Error("APNs send failed");
+  }
+
+  function getStats() {
+    return {
+      ...stats,
+      sessionAlive: !!(session && !session.destroyed && !session.closed),
+      sessionAgeSeconds: sessionConnectedAt
+        ? Math.floor((Date.now() - sessionConnectedAt) / 1000)
+        : 0,
+    };
+  }
+
+  function close() {
+    clearPingTimer();
+    if (session && !session.destroyed) {
+      try {
+        session.close();
+      } catch {
+        // best-effort
+      }
+    }
+    session = null;
+  }
+
+  /**
+   * Record a token-pruning event for the stats counter. Called by the
+   * caller (proxy.js) after it deletes a stale token from storage.
+   */
+  function noteTokenPruned(reason) {
+    if (reason === "BadDeviceToken") stats.pruneOnBadDeviceToken += 1;
+    else if (reason === "Unregistered") stats.pruneOnUnregistered += 1;
+  }
+
+  return {
+    sendPush,
+    getStats,
+    close,
+    noteTokenPruned,
+    // exposed for tests + emergency manual reset
+    _invalidateSession: invalidateSession,
+  };
+}
+
+module.exports = {
+  createApnsClient,
+  isSessionFatalError,
+  shouldPruneToken,
+  parseReason,
+  // exported only for tests
+  FATAL_SESSION_CODES,
+  FATAL_NGHTTP2_CODES,
+};

--- a/relay-proxy/proxy.js
+++ b/relay-proxy/proxy.js
@@ -28,6 +28,7 @@ const { parseAuthHeader, verifyNip98, sha256Hex } = require("./nip98");
 const { createStorage } = require("./storage");
 const { createClientsStorage } = require("./clients");
 const { createRelayPool } = require("./relayPool");
+const { createApnsClient, shouldPruneToken, parseReason } = require("./apnsClient");
 
 const PUBLIC_PRIMARY_URL = process.env.PUBLIC_RELAY_URL || "wss://relay.powr.build";
 
@@ -58,98 +59,26 @@ function alreadySeen(eventId) {
   return false;
 }
 
-// --- State ---
-let cachedJwt = null;
-let cachedJwtTime = 0;
+// --- APNs client (HTTP/2 with GOAWAY-aware reconnection, see apnsClient.js) ---
+const apnsClient = createApnsClient({
+  host: APNS_HOST,
+  topic: APNS_TOPIC,
+  keyId: APNS_KEY_ID,
+  teamId: APNS_TEAM_ID,
+  keyPath: APNS_KEY_PATH,
+  logger: console,
+});
 
-// --- APNs JWT (ES256) ---
-function derToRaw(derSig) {
-  let offset = 2;
-  if (derSig[0] !== 0x30) throw new Error("Invalid DER");
-  if (derSig[2] !== 0x02) throw new Error("Invalid DER");
-  const rLen = derSig[3];
-  const r = derSig.subarray(4, 4 + rLen);
-  offset = 4 + rLen;
-  if (derSig[offset] !== 0x02) throw new Error("Invalid DER");
-  const sLen = derSig[offset + 1];
-  const s = derSig.subarray(offset + 2, offset + 2 + sLen);
-  const rPad = Buffer.alloc(32);
-  r.copy(rPad, Math.max(0, 32 - r.length), Math.max(0, r.length - 32));
-  const sPad = Buffer.alloc(32);
-  s.copy(sPad, Math.max(0, 32 - s.length), Math.max(0, s.length - 32));
-  return Buffer.concat([rPad, sPad]);
-}
-
-function makeApnsJwt() {
-  // Cache JWT for 50 minutes (Apple allows up to 60)
-  const now = Math.floor(Date.now() / 1000);
-  if (cachedJwt && now - cachedJwtTime < 3000) return cachedJwt;
-
-  const key = fs.readFileSync(APNS_KEY_PATH, "utf8");
-  const header = Buffer.from(
-    JSON.stringify({ alg: "ES256", kid: APNS_KEY_ID })
-  ).toString("base64url");
-  const payload = Buffer.from(
-    JSON.stringify({ iss: APNS_TEAM_ID, iat: now })
-  ).toString("base64url");
-  const sigInput = `${header}.${payload}`;
-  const signer = crypto.createSign("SHA256");
-  signer.update(sigInput);
-  const sig = signer.sign(key);
-  const raw = derToRaw(sig);
-  const signature = raw.toString("base64url");
-  cachedJwt = `${header}.${payload}.${signature}`;
-  cachedJwtTime = now;
-  return cachedJwt;
-}
-
-// --- APNs HTTP/2 Client ---
-let apnsClient = null;
-
-function getApnsClient() {
-  if (apnsClient && !apnsClient.destroyed) return apnsClient;
-  apnsClient = http2.connect(`https://${APNS_HOST}`);
-  apnsClient.on("error", (err) => {
-    console.error("[APNs] Connection error:", err.message);
-    apnsClient = null;
-  });
-  apnsClient.on("close", () => {
-    apnsClient = null;
-  });
-  return apnsClient;
-}
-
-// --- Send APNs Push ---
-function sendPush(token, pushPayload) {
-  const jwt = makeApnsJwt();
-  const body = JSON.stringify(pushPayload);
-  const client = getApnsClient();
-
-  return new Promise((resolve, reject) => {
-    const req = client.request({
-      ":method": "POST",
-      ":path": `/3/device/${token}`,
-      authorization: `bearer ${jwt}`,
-      "apns-topic": APNS_TOPIC,
-      "apns-push-type": "alert",
-      "apns-priority": "10",
-      "content-type": "application/json",
-      "content-length": Buffer.byteLength(body),
-    });
-
-    let data = "";
-    req.on("response", (headers) => {
-      const status = headers[":status"];
-      req.on("data", (d) => (data += d));
-      req.on("end", () => {
-        console.log(`[APNs] ${status} ${data || "OK"}`);
-        resolve(status);
-      });
-    });
-    req.on("error", reject);
-    req.write(body);
-    req.end();
-  });
+/**
+ * Send a push and log the result in the legacy `[APNs] <status> <body>`
+ * format so existing log filters / dashboards keep working. Returns
+ * `{status, body}` from APNs; throws if the request itself failed.
+ */
+async function sendPush(token, pushPayload) {
+  const result = await apnsClient.sendPush(token, pushPayload);
+  const tag = result.retried ? " (retried)" : "";
+  console.log(`[APNs] ${result.status} ${result.body || "OK"}${tag}`);
+  return result;
 }
 
 // --- Relay WebSocket ---
@@ -530,6 +459,7 @@ const server = http.createServer((req, res) => {
         last_event_received_at: global.lastEventReceivedAt || null,
         uptime_seconds: Math.floor(process.uptime()),
         public_relay: process.env.PUBLIC_RELAY_URL || RELAY_URL,
+        apns: apnsClient.getStats(),
       })
     );
   } else {
@@ -591,11 +521,13 @@ async function dispatchCaughtEvent({ event, sourceUrl, classification }) {
 
   for (const entry of matchingTokens) {
     try {
-      const status = await sendPush(entry.token, pushPayload);
-      if (status === 410) {
+      const { status, body } = await sendPush(entry.token, pushPayload);
+      if (shouldPruneToken(status, body)) {
         storage.removeToken({ token: entry.token, pubkey: entry.pubkey });
+        const reason = parseReason(body) || (status === 410 ? "Unregistered" : `HTTP ${status}`);
+        apnsClient.noteTokenPruned(reason);
         console.log(
-          `[APNs] Removed stale token: ${entry.token.slice(0, 8)}... for ${entry.pubkey.slice(0, 8)}...`
+          `[APNs] Removed stale token: ${entry.token.slice(0, 8)}... for ${entry.pubkey.slice(0, 8)}... (${reason})`
         );
       }
     } catch (e) {
@@ -639,3 +571,19 @@ server.listen(HTTP_PORT, () => {
   // Primary sub (ws://localhost:7778) — unchanged behavior, broad filter.
   connectRelay();
 });
+
+// Graceful shutdown — close the APNs session so Apple sees a clean
+// disconnect rather than a half-open socket. Helps the next start come up
+// faster and avoids a tail of stranded streams on Apple's side.
+function gracefulShutdown(signal) {
+  console.log(`[Shutdown] ${signal} received — closing APNs session`);
+  try {
+    apnsClient.close();
+  } catch (e) {
+    console.error(`[Shutdown] apnsClient.close threw: ${e.message}`);
+  }
+  // Give in-flight requests up to 2s to drain, then exit.
+  setTimeout(() => process.exit(0), 2000).unref();
+}
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));

--- a/relay-proxy/test/apnsClient.test.js
+++ b/relay-proxy/test/apnsClient.test.js
@@ -1,0 +1,139 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  isSessionFatalError,
+  shouldPruneToken,
+  parseReason,
+  FATAL_SESSION_CODES,
+  FATAL_NGHTTP2_CODES,
+} = require("../apnsClient");
+
+// ---------------------------------------------------------------------------
+// isSessionFatalError
+// ---------------------------------------------------------------------------
+
+test("isSessionFatalError: nullish → false", () => {
+  assert.equal(isSessionFatalError(null), false);
+  assert.equal(isSessionFatalError(undefined), false);
+});
+
+test("isSessionFatalError: GOAWAY-related code triggers", () => {
+  for (const code of FATAL_SESSION_CODES) {
+    assert.equal(
+      isSessionFatalError({ code, message: code }),
+      true,
+      `expected ${code} to be fatal`
+    );
+  }
+});
+
+test("isSessionFatalError: nghttp2 codes in message string trigger", () => {
+  for (const code of FATAL_NGHTTP2_CODES) {
+    assert.equal(
+      isSessionFatalError({ message: `Stream closed with error code ${code}` }),
+      true,
+      `expected message containing ${code} to be fatal`
+    );
+  }
+});
+
+test("isSessionFatalError: GOAWAY substring in message triggers", () => {
+  // The actual error from prod that started this whole investigation.
+  const err = new Error(
+    "New streams cannot be created after receiving a GOAWAY"
+  );
+  assert.equal(isSessionFatalError(err), true);
+});
+
+test("isSessionFatalError: benign per-request error → false", () => {
+  assert.equal(
+    isSessionFatalError({ code: "ERR_HTTP2_INVALID_STREAM", message: "x" }),
+    false,
+    "single-stream errors should NOT invalidate the whole session"
+  );
+  assert.equal(
+    isSessionFatalError(new Error("request timeout")),
+    false
+  );
+});
+
+// ---------------------------------------------------------------------------
+// shouldPruneToken
+// ---------------------------------------------------------------------------
+
+test("shouldPruneToken: 410 always prunes", () => {
+  assert.equal(shouldPruneToken(410, ""), true);
+  assert.equal(shouldPruneToken(410, '{"reason":"Unregistered"}'), true);
+  assert.equal(shouldPruneToken(410, null), true);
+});
+
+test("shouldPruneToken: 400 BadDeviceToken prunes", () => {
+  assert.equal(
+    shouldPruneToken(400, '{"reason":"BadDeviceToken"}'),
+    true,
+    "the bug we're fixing — these previously survived forever"
+  );
+});
+
+test("shouldPruneToken: 400 DeviceTokenNotForTopic prunes", () => {
+  assert.equal(
+    shouldPruneToken(400, '{"reason":"DeviceTokenNotForTopic"}'),
+    true
+  );
+});
+
+test("shouldPruneToken: 400 with other reasons does NOT prune", () => {
+  // PayloadTooLarge means "this push was too big" — the token itself is
+  // still valid; pruning would lose deliverability on the next push.
+  assert.equal(
+    shouldPruneToken(400, '{"reason":"PayloadTooLarge"}'),
+    false
+  );
+  assert.equal(
+    shouldPruneToken(400, '{"reason":"BadCertificate"}'),
+    false
+  );
+  assert.equal(
+    shouldPruneToken(400, ""),
+    false,
+    "no body — be conservative, don't prune"
+  );
+});
+
+test("shouldPruneToken: 200 / 5xx never prune", () => {
+  assert.equal(shouldPruneToken(200, "OK"), false);
+  assert.equal(shouldPruneToken(429, '{"reason":"TooManyRequests"}'), false);
+  assert.equal(shouldPruneToken(500, '{"reason":"InternalServerError"}'), false);
+  assert.equal(shouldPruneToken(503, '{"reason":"ServiceUnavailable"}'), false);
+});
+
+test("shouldPruneToken: accepts pre-parsed body object", () => {
+  assert.equal(
+    shouldPruneToken(400, { reason: "BadDeviceToken" }),
+    true,
+    "callers may pass already-parsed JSON"
+  );
+});
+
+// ---------------------------------------------------------------------------
+// parseReason
+// ---------------------------------------------------------------------------
+
+test("parseReason: extracts JSON reason", () => {
+  assert.equal(parseReason('{"reason":"BadDeviceToken"}'), "BadDeviceToken");
+});
+
+test("parseReason: returns null for empty/non-JSON", () => {
+  assert.equal(parseReason(""), null);
+  assert.equal(parseReason(null), null);
+  assert.equal(parseReason(undefined), null);
+  assert.equal(parseReason("not json"), null);
+});
+
+test("parseReason: passes through pre-parsed objects", () => {
+  assert.equal(parseReason({ reason: "Unregistered" }), "Unregistered");
+  assert.equal(parseReason({ other: "field" }), null);
+});


### PR DESCRIPTION
## Summary

Fixes a real production incident from 2026-04-27 evening: the proxy stopped sending APNs pushes for ~6 hours (~18:35 → ~02:13 EDT). Apple sent a GOAWAY frame; our reconnect logic only detected `error` and `close`. After GOAWAY the session is **not** \`destroyed\` — it just refuses new streams. Cached-session check kept returning the dead one for every \`sendPush\`, producing \`NGHTTP2_REFUSED_STREAM\` per request with no recovery. Compliance events kept being received from the relay; APNs delivery hit zero. Force-closed Clave installs got no NSE wakes for the entire window.

Restarted the proxy manually to recover. This PR makes that scenario self-healing.

Bonus: the user's account had accumulated 199 \`BadDeviceToken\` responses in 24h because we previously only pruned on HTTP 410. Apple lumps 400 \`BadDeviceToken\` and 410 \`Unregistered\` as terminal token states — both now prune.

## Changes

### New \`relay-proxy/apnsClient.js\`
Extracted into a testable module.
- Listens for \`goaway\` and \`frameError\` events explicitly; calls \`invalidateSession(reason)\` to discard the cached session.
- \`sendPush\` catches synchronous throws from \`client.request(...)\` and auto-retries once on a fresh session for fatal-session error codes (\`ERR_HTTP2_GOAWAY_SESSION\`, \`NGHTTP2_REFUSED_STREAM\`, \`ECONNRESET\`, etc.).
- Periodic HTTP/2 PING every 5 min keeps the kernel + Apple's edge socket warm; ping failure invalidates the session before the next real push.
- Operational counters: \`sessionConnects\`, \`sessionInvalidations\`, \`sendOk\`, \`sendFail\`, \`sendRetried\`, \`pruneOnBadDeviceToken\`, \`pruneOnUnregistered\`, \`lastSendAt\`, \`lastFailureAt\`, \`lastFailureReason\`, \`sessionAlive\`, \`sessionAgeSeconds\`.

### \`proxy.js\`
- Swap inline impl for the new module (-94 lines, +42).
- Use \`shouldPruneToken(status, body)\` so \`400 BadDeviceToken\` / \`DeviceTokenNotForTopic\` now prune, not just 410.
- Log the pruning reason: \`[APNs] Removed stale token: ... (BadDeviceToken)\`.
- \`/health\` now includes an \`apns:\` block — lets us spot the "stuck dead" state from outside the process via \`curl\`.
- Graceful shutdown on SIGTERM/SIGINT closes the APNs session cleanly before exit.

### \`test/apnsClient.test.js\`
14 unit tests covering the pure helpers. The exact error string from the prod incident — \`"New streams cannot be created after receiving a GOAWAY"\` — is locked in as a regression guard.

## Test plan
- [x] \`node --check proxy.js\` → OK
- [x] \`node --test test/apnsClient.test.js\` → 14/14 pass
- [x] \`node --test test/\` → 64/65 pass (the 1 failure is the pre-existing \`nip98.test.js\` ESM-on-Node-18 issue documented in PROJECT-STATE.md, unrelated)
- [ ] **Deploy to Dell**: \`sudo cp relay-proxy/proxy.js relay-proxy/apnsClient.js /opt/clave-proxy/ && sudo systemctl restart clave-proxy\`
- [ ] **Verify post-deploy**:
  - [ ] \`curl -sS https://proxy.clave.casa/health | jq .apns\` shows \`sessionAlive: true\` and counters incrementing
  - [ ] After a few signs: \`sendOk\` increments, \`lastSendAt\` updates
  - [ ] After ~24h, the user's stale token is pruned (\`pruneOnBadDeviceToken\` ≥ 1; \`tokens.json\` no longer contains it)
- [ ] **Resilience smoke test (post-deploy, low-pressure)**: monitor \`/health.apns.sessionInvalidations\` over a week — expect a small number (Apple does send periodic GOAWAYs); each invalidation should be followed by a successful \`sendOk\` increment within minutes, proving auto-recovery works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)