### PR TITLE
fix(register): auto re-register with proxy on every launch

### DIFF
--- a/Clave/AppState.swift
+++ b/Clave/AppState.swift
@@ -57,6 +57,36 @@ final class AppState {
         ) { [weak self] _ in
             self?.refreshPendingRequests()
         }
+
+        // Re-register with the proxy whenever iOS hands us a device token.
+        // Catches three real-world failure modes that previously left users
+        // silently unable to receive push-wakes:
+        //  1. iOS rotated the token (Apple does this periodically, especially
+        //     after iOS upgrades) — proxy was holding a stale token.
+        //  2. The user reinstalled Clave from TestFlight — fresh install gets
+        //     a new token, but the existing nsec in Keychain means we never
+        //     hit the importKey/generateKey re-register path.
+        //  3. The proxy lost our token entry (e.g. the tokens.json migration
+        //     wiped legacy entries; future bug we haven't hit yet) — re-
+        //     registering on launch transparently recovers.
+        // Idempotent on the proxy side (upsert), so harmless on the common
+        // case where token+pubkey haven't changed.
+        NotificationCenter.default.addObserver(
+            forName: .apnsDeviceTokenAvailable,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self else { return }
+            if let token = note.object as? String {
+                self.deviceToken = token
+            }
+            // Only register if we already have a key. Onboarding flow handles
+            // the no-key-yet case via the explicit `importKey()` /
+            // `generateKey()` path; no point trying with no nsec to sign.
+            if self.isKeyImported {
+                self.registerWithProxy()
+            }
+        }
     }
 
     // MARK: - Foreground subscription bridge
@@ -102,6 +132,17 @@ final class AppState {
         deviceToken = SharedConstants.sharedDefaults.string(forKey: SharedConstants.deviceTokenKey) ?? ""
         bunkerSecret = SharedStorage.getBunkerSecret()
         loadCachedProfile()
+
+        // Re-register with the proxy on every launch when both a key and a
+        // token are present. Belt to the suspenders of the
+        // .apnsDeviceTokenAvailable observer in init: this catches the
+        // ordering case where iOS handed us the device token *before* loadState
+        // ran (so the observer's `if isKeyImported` check failed at that moment
+        // because the key hadn't been loaded from Keychain yet). Idempotent on
+        // the proxy side.
+        if isKeyImported && !deviceToken.isEmpty {
+            registerWithProxy()
+        }
     }
 
     private func loadCachedProfile() {

--- a/Clave/ClaveApp.swift
+++ b/Clave/ClaveApp.swift
@@ -42,10 +42,13 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         let token = deviceToken.map { String(format: "%02x", $0) }.joined()
         logger.notice("[APNs] Device token: \(token, privacy: .private)")
         SharedConstants.sharedDefaults.set(token, forKey: SharedConstants.deviceTokenKey)
-        // Registration with the proxy is handled by AppState.importKey/generateKey
-        // (on first-time setup) and by the Settings → Register button (on demand).
-        // The AppDelegate doesn't have access to the signer nsec without duplicating
-        // LightEvent.signNip98 logic, so we no longer register from here.
+        // AppDelegate doesn't have direct access to the signer nsec (would have
+        // to duplicate LightEvent.signNip98 logic), so we signal AppState via
+        // NotificationCenter and let it do the actual NIP-98-signed POST.
+        // Catches: iOS-rotated tokens, proxy-side token loss, fresh installs
+        // where the user already had a key from a prior install. Idempotent on
+        // the proxy side (upsert).
+        NotificationCenter.default.post(name: .apnsDeviceTokenAvailable, object: token)
     }
 
     func application(
@@ -244,4 +247,9 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 extension Notification.Name {
     static let signingCompleted = Notification.Name("signingCompleted")
     static let drainPendingPairOps = Notification.Name("drainPendingPairOps")
+    /// Posted by AppDelegate.didRegisterForRemoteNotificationsWithDeviceToken
+    /// every time iOS hands us a device token (every launch + on rotations).
+    /// AppState observes and re-registers with the proxy if a signer key
+    /// exists. Object is the hex-encoded token string.
+    static let apnsDeviceTokenAvailable = Notification.Name("apnsDeviceTokenAvailable")
 }


### PR DESCRIPTION
## Summary

Real tester (npub1whale...) hit a silent push-delivery failure today: their signer pubkey had **zero** APNs tokens registered with the proxy (\`[PRIMARY] Event for pubkey 75fbfcd7... — no registered tokens, skipping\` repeated 63 times in 4h). Foreground L1 worked because it catches via WebSocket and bypasses APNs entirely; everything else silently failed. Their workaround was \"toggle Clave to foreground every time\" — fine as a stopgap, broken as a product.

Root cause: registration with the proxy only happens in \`AppState.importKey()\` / \`generateKey()\` and the manual Settings → Register button. Three real failure modes leave the proxy with a stale or absent token:

1. **iOS rotates the device token** (Apple does this periodically, especially after iOS upgrades). New token from \`didRegisterForRemoteNotificationsWithDeviceToken\` was being saved to UserDefaults but never pushed to the proxy.
2. **User reinstalls Clave from TestFlight** — fresh APNs token, but the existing nsec in Keychain means we never re-hit the importKey/generateKey path.
3. **Proxy-side token loss** (the 2026-04-20 tokens.json migration wiped legacy entries; future bugs may do similar) — no recovery without manual Settings tap.

The previous design comment in \`ClaveApp.swift\` claimed AppDelegate \"doesn't have access to the signer nsec without duplicating LightEvent.signNip98 logic\" — true, but solvable by signaling AppState via NotificationCenter and letting it do the actual NIP-98-signed POST.

## Changes

- \`Clave/ClaveApp.swift\` \`didRegisterForRemoteNotificationsWithDeviceToken\` now posts \`.apnsDeviceTokenAvailable\` every time iOS hands us a token. New Notification.Name added to the existing extension.
- \`Clave/AppState.swift\`:
  - \`init\` adds an observer for \`.apnsDeviceTokenAvailable\` that updates \`deviceToken\` and calls \`registerWithProxy()\` if \`isKeyImported\`.
  - \`loadState()\` calls \`registerWithProxy()\` if both key and stored token are present. Belt-and-suspenders for the cold-launch ordering case where iOS handed us the token via the AppDelegate path *before* \`loadState()\` ran (so the observer's \`isKeyImported\` check failed at that moment because the key hadn't loaded from Keychain yet).

Both paths are idempotent on the proxy side (the /register endpoint upserts), so the common case of \"token+pubkey unchanged\" is harmless.

## Test plan
- [x] \`xcodebuild -scheme Clave -destination 'generic/platform=iOS' build\` → BUILD SUCCEEDED
- [x] \`xcodebuild test\` on iPhone 17 Pro Max sim (iOS 26.4) → TEST SUCCEEDED
- [ ] **Device test (build 26 TestFlight)** — reproduce the tester's symptom + verify recovery:
  - [ ] On a phone with no current token entry on the proxy (force-removable via \`sg clave-proxy -c 'cat /opt/clave-proxy/tokens.json' | jq\` to confirm), launch build 26.
  - [ ] Within ~1s of launch, check \`curl https://proxy.clave.casa/health | jq .total_tokens\` — should increment by 1.
  - [ ] Send a sign request from a paired client with Clave force-closed → NSE wakes → request signs.
- [ ] **Real tester confirmation**: ship build 26 → ask npub1whale... to install → check whether their 75fbfcd7... pubkey appears in tokens.json without them tapping Settings → Register.

## Closes
BACKLOG: \"Auto-register on launch (low priority): loadState() doesn't re-register with the proxy — only importKey()/generateKey() do.\" Promoted to High after this incident.

## Why this didn't make build 25
Build 25 just shipped (PR #13 merged + archived). This is a follow-up for build 26. Independent enough to merge separately; no conflicts with PR #14 (proxy resilience, server-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)