### PR TITLE
fix(notifications): clear NSE-delivered banners on TTL purge + sweep prior-wake blanks

### DIFF
--- a/Clave.xcodeproj/project.pbxproj
+++ b/Clave.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		AE01F2A3B4C5D6E700000006 /* Nip19.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE01F2A3B4C5D6E700000004 /* Nip19.swift */; };
 		AE01F2A3B4C5D6E700000008 /* SharedKeychain+Enumeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE01F2A3B4C5D6E700000007 /* SharedKeychain+Enumeration.swift */; };
 		B0EBA01E2F90AB01000A0001 /* PendingApprovalBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0EBA01E2F90AB01000A0002 /* PendingApprovalBanner.swift */; };
+		B0EBA01E2F90AB01000A0003 /* PendingApprovalBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0EBA01E2F90AB01000A0002 /* PendingApprovalBanner.swift */; };
 		B2551C1A4D99451B8AABCA1763DF333C /* DeeplinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7835E9DD22C448C3893D6D945AFFEA16 /* DeeplinkRouter.swift */; };
 		BD247C1AD3A7497E8DF29530 /* ClientPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894FE9FF88CD485ABCD31C05 /* ClientPermissions.swift */; };
 		C1A4F2B3C5D6E700000011 /* AccountTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A4F2B3C5D6E700000010 /* AccountTheme.swift */; };
@@ -488,6 +489,7 @@
 				AE01F2A3B4C5D6E700000003 /* ActivitySummary.swift in Sources */,
 				AE01F2A3B4C5D6E700000006 /* Nip19.swift in Sources */,
 				B2551C1A4D99451B8AABCA1763DF333C /* DeeplinkRouter.swift in Sources */,
+				B0EBA01E2F90AB01000A0003 /* PendingApprovalBanner.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ClaveNSE/NotificationService.swift
+++ b/ClaveNSE/NotificationService.swift
@@ -32,9 +32,35 @@ class NotificationService: UNNotificationServiceExtension {
         logger.notice("[ClaveNSE] didReceive called")
 
         Task {
+            // Clean up blanks left in Notification Center by PRIOR NSE wakes
+            // before doing this wake's work. NSE's old self-cleanup pattern
+            // (call `removeDeliveredNotifications` immediately after
+            // `contentHandler`) is racy because the process exits before iOS
+            // commits the notification. Targeting prior wakes is race-free —
+            // those notifications are already committed; from a fresh NSE
+            // process the remove call reliably runs.
+            await sweepPriorBlankNotifications()
+
             let result = await handleSigningRequest(userInfo: request.content.userInfo)
             deliverContent(result: result)
         }
+    }
+
+    /// Removes empty-title-and-body notifications committed by prior NSE
+    /// wakes. Mirrors `Clave/Views/Components/NotificationCenterSweep.swift`
+    /// but runs from the NSE process so cleanup happens between events
+    /// without requiring the user to foreground Clave. Fire-and-forget the
+    /// final remove call (no completion handler available); awaiting the
+    /// `deliveredNotifications()` lookup keeps NSE alive long enough for
+    /// the XPC message to be issued before the process exits.
+    private func sweepPriorBlankNotifications() async {
+        let center = UNUserNotificationCenter.current()
+        let delivered = await center.deliveredNotifications()
+        let snapshots = delivered.map(DeliveredNotificationSnapshot.init(from:))
+        let blankIds = PendingApprovalBanner.blankDeliveredIds(in: snapshots)
+        guard !blankIds.isEmpty else { return }
+        center.removeDeliveredNotifications(withIdentifiers: blankIds)
+        logger.notice("[ClaveNSE] Swept \(blankIds.count, privacy: .public) blank notification(s) from prior wakes")
     }
 
     private func deliverContent(result: SigningResult) {

--- a/ClaveTests/LockScreenActionRoutingTests.swift
+++ b/ClaveTests/LockScreenActionRoutingTests.swift
@@ -56,4 +56,121 @@ final class LockScreenActionRoutingTests: XCTestCase {
         XCTAssertEqual(content.title, "Approve Signing Request")
         XCTAssertEqual(content.interruptionLevel, .active)
     }
+
+    // MARK: - NSE-delivered banner cleanup (PendingApprovalBanner.clear extension)
+    //
+    // `clear(requestId:)` previously only removed locally-scheduled banners
+    // (identifier prefix `"pending-approval-"`). NSE-delivered banners use
+    // the APNs notification identifier (proxy-assigned), so the only stable
+    // way to find them is by `categoryIdentifier` + `userInfo.pendingRequestId`.
+    // These tests verify the pure matcher; the runtime async path is exercised
+    // by manual on-device smoke (TTL purge with a follow request was the
+    // motivating bug — banner stranded in NC after the request expired).
+
+    func test_nseDeliveredIds_matchesCorrectRequestByCategoryAndUserInfo() {
+        let requestId = "target-request-id"
+        let delivered: [DeliveredNotificationSnapshot] = [
+            // Match: NSE-delivered for the target request
+            DeliveredNotificationSnapshot(
+                identifier: "apns-event-1",
+                title: "Approve Signing Request",
+                body: "primal wants to sign Note",
+                categoryIdentifier: PendingApprovalCategory.identifier,
+                userInfo: ["pendingRequestId": requestId, "event_id": "abc"]
+            ),
+            // Same category but different request — must NOT match
+            DeliveredNotificationSnapshot(
+                identifier: "apns-event-2",
+                title: "Approve Signing Request",
+                body: "yakihonne wants to sign Reaction",
+                categoryIdentifier: PendingApprovalCategory.identifier,
+                userInfo: ["pendingRequestId": "different-request"]
+            ),
+            // Same userInfo but different category — must NOT match
+            DeliveredNotificationSnapshot(
+                identifier: "apns-event-3",
+                title: "Approve Signing Request",
+                body: "wrong category",
+                categoryIdentifier: "OTHER_CATEGORY",
+                userInfo: ["pendingRequestId": requestId]
+            ),
+            // Missing userInfo pendingRequestId — must NOT match
+            DeliveredNotificationSnapshot(
+                identifier: "apns-event-4",
+                title: "Approve Signing Request",
+                body: "no request id",
+                categoryIdentifier: PendingApprovalCategory.identifier,
+                userInfo: [:]
+            ),
+        ]
+
+        let result = PendingApprovalBanner.nseDeliveredIds(forRequest: requestId, in: delivered)
+        XCTAssertEqual(result, ["apns-event-1"])
+    }
+
+    func test_nseDeliveredIds_returnsEmptyWhenNoMatch() {
+        let delivered: [DeliveredNotificationSnapshot] = [
+            DeliveredNotificationSnapshot(
+                identifier: "x",
+                title: "y",
+                body: "z",
+                categoryIdentifier: PendingApprovalCategory.identifier,
+                userInfo: ["pendingRequestId": "other"]
+            )
+        ]
+        XCTAssertTrue(
+            PendingApprovalBanner.nseDeliveredIds(forRequest: "missing", in: delivered).isEmpty
+        )
+    }
+
+    func test_nseDeliveredIds_returnsEmptyForEmptyDelivered() {
+        XCTAssertTrue(
+            PendingApprovalBanner.nseDeliveredIds(forRequest: "anything", in: []).isEmpty
+        )
+    }
+
+    // MARK: - Blank notification cleanup (NSE-side sweep at start of next wake)
+    //
+    // NSE's silent-success path leaves an empty-title-empty-body notification
+    // in NC. Old NSE-self-cleanup-after-contentHandler was racy. This pure
+    // filter feeds the new NSE-side sweep that runs at the start of each fresh
+    // wake — race-free because the notifications it removes were committed by
+    // earlier wakes (already in the system).
+
+    func test_blankDeliveredIds_findsEmptyTitleAndBody() {
+        let delivered: [DeliveredNotificationSnapshot] = [
+            blankSnap(id: "blank-empty"),
+            blankSnap(id: "blank-spaces", title: " ", body: " "),
+            blankSnap(id: "blank-whitespace", title: "\n\t ", body: "\t\n"),
+            blankSnap(id: "kept-title", title: "Approve Signing Request", body: ""),
+            blankSnap(id: "kept-body", title: "", body: "Relay rejected"),
+            blankSnap(id: "kept-both", title: "Signing Failed", body: "Bad sig"),
+        ]
+
+        let result = Set(PendingApprovalBanner.blankDeliveredIds(in: delivered))
+        XCTAssertEqual(result, Set(["blank-empty", "blank-spaces", "blank-whitespace"]))
+    }
+
+    func test_blankDeliveredIds_returnsEmptyForNoBlanks() {
+        let delivered = [
+            blankSnap(id: "kept", title: "Approve Signing Request", body: "x")
+        ]
+        XCTAssertTrue(PendingApprovalBanner.blankDeliveredIds(in: delivered).isEmpty)
+    }
+
+    private func blankSnap(
+        id: String,
+        title: String = "",
+        body: String = "",
+        category: String = "",
+        userInfo: [AnyHashable: Any] = [:]
+    ) -> DeliveredNotificationSnapshot {
+        DeliveredNotificationSnapshot(
+            identifier: id,
+            title: title,
+            body: body,
+            categoryIdentifier: category,
+            userInfo: userInfo
+        )
+    }
 }

--- a/Shared/PendingApprovalBanner.swift
+++ b/Shared/PendingApprovalBanner.swift
@@ -80,11 +80,102 @@ enum PendingApprovalBanner {
     }
 
     /// Removes the delivered/pending banner for a given request id. Called when
-    /// the user approves or denies a pending request via the UI so the banner
-    /// doesn't linger in Notification Center.
+    /// the user approves, denies, or the TTL purge expires a pending request,
+    /// so the banner doesn't linger in Notification Center.
+    ///
+    /// Two flavors of banner can exist for a given pending request:
+    ///
+    ///   1. Locally-scheduled by `schedule(...)` above — identifier
+    ///      `"pending-approval-<requestId>"`. The synchronous remove below
+    ///      handles these.
+    ///   2. NSE-delivered via APNs (`ClaveNSE/NotificationService.swift`
+    ///      `.pending` case). These use the APNs request identifier (proxy-
+    ///      assigned, not our prefix), so we have to match by `userInfo`
+    ///      payload. The async path below enumerates delivered notifications
+    ///      and removes any whose `categoryIdentifier` is ours and whose
+    ///      `pendingRequestId` userInfo matches.
+    ///
+    /// Without (2), a TTL-purged or approved/denied request leaves an NSE-
+    /// delivered banner stranded in Notification Center; long-pressing
+    /// Approve from the stale banner would silently fail because the
+    /// `SharedStorage` row is already gone.
     static func clear(requestId: String) {
-        let identifier = "pending-approval-\(requestId)"
-        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
-        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [identifier])
+        let center = UNUserNotificationCenter.current()
+        let localIdentifier = "pending-approval-\(requestId)"
+        center.removePendingNotificationRequests(withIdentifiers: [localIdentifier])
+        center.removeDeliveredNotifications(withIdentifiers: [localIdentifier])
+
+        Task {
+            let delivered = await center.deliveredNotifications()
+            let snapshots = delivered.map(DeliveredNotificationSnapshot.init(from:))
+            let nseIdentifiers = nseDeliveredIds(forRequest: requestId, in: snapshots)
+            guard !nseIdentifiers.isEmpty else { return }
+            center.removeDeliveredNotifications(withIdentifiers: nseIdentifiers)
+            logger.notice("[Banner] Cleared \(nseIdentifiers.count, privacy: .public) NSE-delivered banner(s) for request \(requestId.prefix(8), privacy: .public)")
+        }
+    }
+
+    /// Pure filter: returns identifiers of notifications that are NSE-delivered
+    /// pending-approval banners for the given request id. Extracted so unit
+    /// tests can verify the matcher without touching `UNUserNotificationCenter`.
+    static func nseDeliveredIds(
+        forRequest requestId: String,
+        in delivered: [DeliveredNotificationSnapshot]
+    ) -> [String] {
+        delivered.compactMap { snapshot in
+            guard snapshot.categoryIdentifier == PendingApprovalCategory.identifier else { return nil }
+            guard let id = snapshot.userInfo["pendingRequestId"] as? String,
+                  id == requestId else { return nil }
+            return snapshot.identifier
+        }
+    }
+
+    /// Pure filter: returns identifiers of notifications whose title and body
+    /// are both empty after trimming. Used by the NSE-side sweep that runs at
+    /// the start of each wake to clean up blanks left behind by prior wakes
+    /// (see `ClaveNSE/NotificationService.swift`). Mirrors the logic in
+    /// `Clave/Views/Components/NotificationCenterSweep.swift` but runs in a
+    /// context where the racy NSE-self-cleanup pattern can't reach.
+    static func blankDeliveredIds(
+        in delivered: [DeliveredNotificationSnapshot]
+    ) -> [String] {
+        delivered.compactMap { snapshot in
+            let trimmedTitle = snapshot.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmedBody = snapshot.body.trimmingCharacters(in: .whitespacesAndNewlines)
+            return (trimmedTitle.isEmpty && trimmedBody.isEmpty) ? snapshot.identifier : nil
+        }
+    }
+}
+
+/// Test-friendly snapshot of the fields we filter on. Initialized from a
+/// `UNNotification` at runtime; constructed directly in unit tests since
+/// `UNNotification`'s designated initializer isn't accessible.
+struct DeliveredNotificationSnapshot {
+    let identifier: String
+    let title: String
+    let body: String
+    let categoryIdentifier: String
+    let userInfo: [AnyHashable: Any]
+
+    init(from notification: UNNotification) {
+        self.identifier = notification.request.identifier
+        self.title = notification.request.content.title
+        self.body = notification.request.content.body
+        self.categoryIdentifier = notification.request.content.categoryIdentifier
+        self.userInfo = notification.request.content.userInfo
+    }
+
+    init(
+        identifier: String,
+        title: String,
+        body: String,
+        categoryIdentifier: String,
+        userInfo: [AnyHashable: Any]
+    ) {
+        self.identifier = identifier
+        self.title = title
+        self.body = body
+        self.categoryIdentifier = categoryIdentifier
+        self.userInfo = userInfo
     }
 }


### PR DESCRIPTION
Stacks onto PR #24 (build 54). Merging this lands the fix on `feat/v0.2.0-build52`; build 55 archives from there.

## Summary

Two related Notification Center cleanup issues surfaced during the build 54 TTL-purge smoke test:

1. **Pending banners stranded in NC after TTL purge / approve / deny.** `PendingApprovalBanner.clear` only matched locally-scheduled banners (identifier prefix `pending-approval-`). NSE-delivered banners use the APNs notification identifier, so the only stable match is `categoryIdentifier == PendingApprovalCategory.identifier` AND `userInfo["pendingRequestId"]` equality. Without the fix, a stranded banner could long-press → Approve and silently no-op (the `SharedStorage` row is already gone). The new code path also catches the lock-screen action-tap-on-stale-banner case for free.

2. **NSE silent-success blanks accumulated in NC.** NSE's self-cleanup-after-`contentHandler` was racy — process exits before iOS commits, remove no-ops. Existing main-app `sweepBlankNotifications()` only runs on `scenePhase .active`. Added an NSE-side sweep at the start of each fresh wake that targets prior wakes' blanks (race-free — those notifications are already committed).

## Changes

- `Shared/PendingApprovalBanner.swift`: extend `clear(requestId:)` with async enumerate-and-remove of NSE-delivered matches; extract pure filter helpers `nseDeliveredIds(forRequest:in:)` and `blankDeliveredIds(in:)`; add test-friendly `DeliveredNotificationSnapshot` type.
- `ClaveNSE/NotificationService.swift`: `await sweepPriorBlankNotifications()` before signing work.
- `Clave.xcodeproj/project.pbxproj`: add `PendingApprovalBanner.swift` to the ClaveNSE target Sources phase (new build-file ref `B0EBA01E2F90AB01000A0003`).
- `ClaveTests/LockScreenActionRoutingTests.swift`: 5 new pure-filter tests covering matcher branches.

## Risk

- **NSE budget:** adds one XPC round-trip (`getDeliveredNotifications`) before signing. Typical ~100ms. Worst case if it hangs is NSE 30s timeout — same failure mode as today, no regression.
- **Pbxproj edit:** Debug + 231-test suite green; Archive (Release) verified when build 55 archives cleanly.
- Worst-case fix-1 failure mode is no-op (reverts to today's "stale banner until next foregrounding" behavior) — no new regression.

## Test plan

- [x] 231/231 ClaveTests pass on iPhone 17 / iOS 26.4
- [ ] Build 55 archive succeeds (Release config — proves pbxproj edit)
- [ ] On-device smoke (build 55):
  - [ ] TTL purge a follow request → NC banner disappears within seconds of in-app surface clearing
  - [ ] Approve a pending request from InboxView → any NSE-delivered banner for it disappears
  - [ ] Stream pre-approved kind:1 events → NC blanks don't pile up
  - [ ] Lock-screen long-press Approve still routes to action handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)