### PR TITLE
chore: NIP-46 wire-trace observability for client debugging

### DIFF
--- a/Clave/AppState.swift
+++ b/Clave/AppState.swift
@@ -2,7 +2,10 @@ import Foundation
 import CryptoKit
 import NostrSDK
 import Observation
+import os.log
 import UIKit
+
+private let logger = Logger(subsystem: "dev.nostr.clave", category: "pair")
 
 enum ClaveError: LocalizedError {
     case noSignerKey
@@ -1917,6 +1920,7 @@ final class AppState {
         // Use the explicitly-provided signer (e.g. boundAccountPubkey from deeplink)
         // or fall back to the current account — matching unpairClientWithProxy's pattern.
         let resolvedSigner = signer ?? signerPubkeyHex
+        logger.notice("[Pair] pair-client begin client=\(clientPubkey.prefix(8), privacy: .public) signer=\(resolvedSigner.prefix(8), privacy: .public) relays=\(relayUrls.count, privacy: .public)")
         SharedStorage.setClientRelayUrls(pubkey: clientPubkey, relayUrls: relayUrls, signer: resolvedSigner)
 
         // Layer 1: relay-set may have changed; refresh the foreground sub.
@@ -1929,24 +1933,34 @@ final class AppState {
         // the correct account. Matches unpairClientWithProxy's capture pattern.
         let capturedSigner = resolvedSigner
         guard !capturedSigner.isEmpty,
-              let nsec = SharedKeychain.loadNsec(for: capturedSigner) else { return }
+              let nsec = SharedKeychain.loadNsec(for: capturedSigner) else {
+            logger.error("[Pair] pair-client abort: empty signer or no nsec in Keychain client=\(clientPubkey.prefix(8), privacy: .public)")
+            return
+        }
         let privateKey: Data
         do {
             privateKey = try Bech32.decodeNsec(nsec)
         } catch {
+            logger.error("[Pair] pair-client abort: Bech32 decode failed err=\(error.localizedDescription, privacy: .public)")
             return
         }
 
         let proxyURL = SharedConstants.sharedDefaults.string(forKey: SharedConstants.proxyURLKey)
             ?? SharedConstants.defaultProxyURL
         let pairURL = "\(proxyURL)/pair-client"
-        guard let url = URL(string: pairURL) else { return }
+        guard let url = URL(string: pairURL) else {
+            logger.error("[Pair] pair-client abort: invalid URL=\(pairURL, privacy: .public)")
+            return
+        }
 
         let bodyDict: [String: Any] = [
             "client_pubkey": clientPubkey,
             "relay_urls": relayUrls
         ]
-        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else { return }
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else {
+            logger.error("[Pair] pair-client abort: body serialization failed")
+            return
+        }
         let bodyHash = SHA256.hash(data: bodyData).map { String(format: "%02x", $0) }.joined()
 
         let authHeader: String
@@ -1958,6 +1972,7 @@ final class AppState {
                 bodySha256Hex: bodyHash
             )
         } catch {
+            logger.error("[Pair] pair-client abort: NIP-98 sign failed err=\(error.localizedDescription, privacy: .public)")
             return
         }
 
@@ -1968,10 +1983,22 @@ final class AppState {
         request.setValue(authHeader, forHTTPHeaderField: "X-Clave-Auth")
         request.httpBody = bodyData
 
-        URLSession.shared.dataTask(with: request) { _, response, _ in
+        URLSession.shared.dataTask(with: request) { _, response, error in
             let http = response as? HTTPURLResponse
-            if http?.statusCode == 200 { return }
+            if http?.statusCode == 200 {
+                logger.notice("[Pair] pair-client ok client=\(clientPubkey.prefix(8), privacy: .public) signer=\(capturedSigner.prefix(8), privacy: .public)")
+                return
+            }
             // Any non-200 (including network error → http == nil) queues for retry.
+            let statusStr: String
+            if let code = http?.statusCode {
+                statusStr = "\(code)"
+            } else if let error {
+                statusStr = "net-err:\(error.localizedDescription)"
+            } else {
+                statusStr = "no-response"
+            }
+            logger.error("[Pair] pair-client failed status=\(statusStr, privacy: .public) — queued for retry client=\(clientPubkey.prefix(8), privacy: .public)")
             let op = PairOp(
                 id: UUID().uuidString,
                 kind: .pair,
@@ -2004,22 +2031,33 @@ final class AppState {
         // failure closure enqueues the PairOp under the correct account
         // even if the user-driven account switch races the in-flight request.
         let capturedSigner = signer ?? signerPubkeyHex
+        logger.notice("[Pair] unpair-client begin client=\(clientPubkey.prefix(8), privacy: .public) signer=\(capturedSigner.prefix(8), privacy: .public)")
         guard !capturedSigner.isEmpty,
-              let nsec = SharedKeychain.loadNsec(for: capturedSigner) else { return }
+              let nsec = SharedKeychain.loadNsec(for: capturedSigner) else {
+            logger.error("[Pair] unpair-client abort: empty signer or no nsec in Keychain client=\(clientPubkey.prefix(8), privacy: .public)")
+            return
+        }
         let privateKey: Data
         do {
             privateKey = try Bech32.decodeNsec(nsec)
         } catch {
+            logger.error("[Pair] unpair-client abort: Bech32 decode failed err=\(error.localizedDescription, privacy: .public)")
             return
         }
 
         let proxyURL = SharedConstants.sharedDefaults.string(forKey: SharedConstants.proxyURLKey)
             ?? SharedConstants.defaultProxyURL
         let unpairURL = "\(proxyURL)/unpair-client"
-        guard let url = URL(string: unpairURL) else { return }
+        guard let url = URL(string: unpairURL) else {
+            logger.error("[Pair] unpair-client abort: invalid URL=\(unpairURL, privacy: .public)")
+            return
+        }
 
         let bodyDict: [String: Any] = ["client_pubkey": clientPubkey]
-        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else { return }
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else {
+            logger.error("[Pair] unpair-client abort: body serialization failed")
+            return
+        }
         let bodyHash = SHA256.hash(data: bodyData).map { String(format: "%02x", $0) }.joined()
 
         let authHeader: String
@@ -2031,6 +2069,7 @@ final class AppState {
                 bodySha256Hex: bodyHash
             )
         } catch {
+            logger.error("[Pair] unpair-client abort: NIP-98 sign failed err=\(error.localizedDescription, privacy: .public)")
             return
         }
 
@@ -2041,9 +2080,21 @@ final class AppState {
         request.setValue(authHeader, forHTTPHeaderField: "X-Clave-Auth")
         request.httpBody = bodyData
 
-        URLSession.shared.dataTask(with: request) { _, response, _ in
+        URLSession.shared.dataTask(with: request) { _, response, error in
             let http = response as? HTTPURLResponse
-            if http?.statusCode == 200 { return }
+            if http?.statusCode == 200 {
+                logger.notice("[Pair] unpair-client ok client=\(clientPubkey.prefix(8), privacy: .public) signer=\(capturedSigner.prefix(8), privacy: .public)")
+                return
+            }
+            let statusStr: String
+            if let code = http?.statusCode {
+                statusStr = "\(code)"
+            } else if let error {
+                statusStr = "net-err:\(error.localizedDescription)"
+            } else {
+                statusStr = "no-response"
+            }
+            logger.error("[Pair] unpair-client failed status=\(statusStr, privacy: .public) — queued for retry client=\(clientPubkey.prefix(8), privacy: .public)")
             let op = PairOp(
                 id: UUID().uuidString,
                 kind: .unpair,

--- a/ClaveTests/LogExporterFormattingTests.swift
+++ b/ClaveTests/LogExporterFormattingTests.swift
@@ -58,7 +58,7 @@ final class LogExporterFormattingTests: XCTestCase {
         // by main-app OSLogStore; intentionally excluded.
         let expected: Set<String> = [
             "relay", "signer", "storage", "apns", "app",
-            "fg-sub", "banner", "nc-sweep"
+            "fg-sub", "banner", "nc-sweep", "pair"
         ]
         let actual = Set(LogExporter.allCategories)
         XCTAssertEqual(actual, expected,

--- a/Shared/LightSigner.swift
+++ b/Shared/LightSigner.swift
@@ -118,8 +118,21 @@ enum LightSigner {
             return result
         }
 
-        let params = json["params"] as? [String] ?? []
-        logger.notice("[LightSigner] Method: \(method, privacy: .public)")
+        let params: [String]
+        if let strs = json["params"] as? [String] {
+            params = strs
+        } else {
+            // Some clients send mixed-type params (e.g. an object for sign_event
+            // instead of the spec-required JSON-stringified string). Without
+            // this log, the request silently degrades to "missing params"
+            // downstream and the wire trace can't tell shape-mismatch from
+            // genuinely-missing-params. Helps client-side debugging.
+            if let raw = json["params"] {
+                logger.warning("[LightSigner] params not [String]: type=\(String(describing: type(of: raw)), privacy: .public) method=\(method, privacy: .public) id=\(requestId.prefix(8), privacy: .public)")
+            }
+            params = []
+        }
+        logger.notice("[LightSigner] Method: \(method, privacy: .public) id=\(requestId.prefix(8), privacy: .public)")
 
         // Extract event kind for sign_event
         let eventKind = extractEventKind(method: method, params: params)
@@ -130,6 +143,13 @@ enum LightSigner {
         // --- Per-client permission checks ---
         if method == "connect" {
             // connect params: [remote-signer-pubkey, optional-secret, optional-perms]
+            // Audit-2: warn (don't reject) when params[0] doesn't match this
+            // signer's pubkey. Routing already worked via the kind:24133 #p
+            // tag so a mismatch is informational — but it's a useful diagnostic
+            // for clients that pick the wrong target in multi-account flows.
+            if let target = params.first, !target.isEmpty, target != signerPubkey {
+                logger.warning("[LightSigner] connect target mismatch: params[0]=\(target.prefix(8), privacy: .public) signer=\(signerPubkey.prefix(8), privacy: .public)")
+            }
             let providedSecret = params.count >= 2 ? params[1] : ""
             let expectedSecret = SharedStorage.getBunkerSecret(for: signerPubkey)
 

--- a/Shared/LogExporter.swift
+++ b/Shared/LogExporter.swift
@@ -18,7 +18,7 @@ enum LogExporter {
     /// are silently filtered out of "Copy Recent Logs" — the user becomes blind
     /// to that code path's activity.
     static let allCategories: [String] = [
-        "relay", "signer", "storage", "apns", "app", "fg-sub", "banner", "nc-sweep"
+        "relay", "signer", "storage", "apns", "app", "fg-sub", "banner", "nc-sweep", "pair"
     ]
 
     /// Fetch main-app logs from the unified log store within the given time window.


### PR DESCRIPTION
## Summary

Two observability-only changes to make Clave a cleaner reference signer for debugging NIP-46 client implementations (specifically: investigating Wisp client-side pairing flake while Jumble + noStrudel work as controls). No behavior change in either commit.

**LightSigner.swift** ([5990335](../commit/5990335))
- `[LightSigner] Method:` log gets `id=<8-char>` suffix so every wire-trace step is correlatable to one RPC
- `connect` warns (doesn't reject) when `params[0]` doesn't match this signer's pubkey — closes [BACKLOG Audit-2](../blob/main/../hq/clave/BACKLOG.md)
- New warning when `params` cast falls through (client sent mixed-type instead of `[String]`); reports actual type. Distinguishes shape-mismatch from genuinely-missing-params.

**AppState.swift** ([ca98b5d](../commit/ca98b5d))
- New `"pair"` Logger category — added to `LogExporter.allCategories` + regression test
- `pairClientWithProxy` + `unpairClientWithProxy` had zero log lines and five silent-return points each. Now log: begin (client/signer/relays), each early-return reason (empty signer, no nsec, Bech32 decode, URL/body/NIP-98 failures), and response (200 OK or status/net-err with retry context).
- Pure observability. Existing retry-queue behavior on non-200 unchanged. Privacy-safe: `privacy: .public` only on already-public values (8-char pubkey prefixes, status codes, error messages); full pubkeys never logged.

## Why now

When debugging Wisp's NIP-46 implementation against Clave, the failure point needs to be unambiguous from logs alone. Previously a `pair-client` call could fail at any of five guard points with no breadcrumb — making it impossible to tell from iOS-side traces whether a Wisp pairing failed because Wisp didn't trigger the call, because Clave's NIP-98 sign failed, or because the proxy 5xx'd. Same for the LightSigner request id correlation: noStrudel + Wisp interleaving in one capture session needs per-RPC correlation to compare.

Companion ask: Stage 1 of [the Wisp debugging plan](../../../.claude/plans/i-m-having-some-issues-staged-sutton.md) (capture clean noStrudel control trace + Wisp failure trace via `~/hq/clave/scripts/capture-test.sh`) is dramatically more useful with these breadcrumbs in place.

## Test plan

- [x] `xcodebuild test -skip-testing:ClaveUITests` passes baseline (build 62 / `1e081e7`)
- [x] `xcodebuild test -skip-testing:ClaveUITests` passes post-change (`ca98b5d`)
- [x] `LogExporterFormattingTests.testAllCategories_includesEveryShippedCategory` updated to include `"pair"`
- [ ] Internal TestFlight smoke: pair Clave with noStrudel via nostrconnect → verify `[Pair] pair-client begin` + `[Pair] pair-client ok` in iOS log; verify `[LightSigner] Method: connect id=…` lines correlate across multiple RPCs
- [ ] Stage 1 capture (separate task): use `capture-test.sh` to grab control + Wisp traces with these breadcrumbs in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)