### PR TITLE
chore(proxy): evict permanently-failing relays from secondary pool

### DIFF
--- a/relay-proxy/relayPool.js
+++ b/relay-proxy/relayPool.js
@@ -18,6 +18,16 @@ function createRelayPool({
   reconnectMaxMs = 600_000, // 10 min
   pingIntervalMs = PING_INTERVAL_MS,
   pongTimeoutMs = PONG_TIMEOUT_MS,
+  // Evict relays that fail to reach `open` state this many times in a row
+  // without ever succeeding once. Catches relays that are permanently
+  // broken from this proxy's perspective (403 NIP-42-AUTH-required like
+  // nostr.wine, 502/down like garden.zap.cooking) without disturbing
+  // healthy-but-flapping relays that actually connect successfully.
+  // Default 10 — with the standard backoff schedule (1s, 2s, 4s, …,
+  // capped at 600s), 10 failures takes ~17 minutes; long enough to
+  // ride out a real outage, short enough to stop wasting resources on
+  // a permanent dead relay.
+  maxFailuresWithoutSuccess = 10,
 } = {}) {
   const pool = new Map();
 
@@ -85,6 +95,7 @@ function createRelayPool({
     entry.ws.on("open", () => {
       entry.state = "ready";
       entry.backoffMs = reconnectInitialMs; // reset backoff on success
+      entry.successfulOpens++;
       logger.log(`[RelayPool] ${entry.url} connected`);
       sendReq(entry);
       startHeartbeat(entry);
@@ -118,6 +129,26 @@ function createRelayPool({
       entry.state = "closed";
       entry.failures++;
       stopHeartbeat(entry);
+      // Permanent-failure eviction: relay has never managed to reach `open`
+      // and has now failed `maxFailuresWithoutSuccess` times. Stop the
+      // reconnect loop. Entry stays in the pool with `evicted: true` so
+      // refCount tracking still works for `releaseRelay`. When the last
+      // ref drops, the entry is deleted; a future `addRelay` call (after
+      // a fresh pair) creates a brand-new entry and gives the relay
+      // another chance.
+      if (
+        !entry.evicted &&
+        entry.successfulOpens === 0 &&
+        entry.failures >= maxFailuresWithoutSuccess
+      ) {
+        entry.evicted = true;
+        entry.state = "evicted";
+        logger.error(
+          `[RelayPool] ${entry.url} permanently failed after ${entry.failures} attempts ` +
+          `(no successful opens) — releasing from active reconnect; refCount=${entry.refCount}`
+        );
+        return;
+      }
       scheduleReconnect(entry);
     });
 
@@ -137,6 +168,10 @@ function createRelayPool({
     const existing = pool.get(url);
     if (existing) {
       existing.refCount++;
+      // Don't reattempt connection on an evicted entry — the eviction
+      // verdict stands until refCount drops to 0 and the entry is deleted.
+      // A fresh `addRelay` after deletion creates a new entry that will
+      // try again from scratch.
       return;
     }
     const entry = {
@@ -146,6 +181,8 @@ function createRelayPool({
       state: "connecting",
       backoffMs: reconnectInitialMs,
       failures: 0,
+      successfulOpens: 0,
+      evicted: false,
       reconnectTimer: null,
       pingTimer: null,
       pongTimer: null,
@@ -185,6 +222,8 @@ function createRelayPool({
       refCount: entry.refCount,
       state: entry.state,
       failures: entry.failures,
+      successfulOpens: entry.successfulOpens,
+      evicted: entry.evicted,
     };
   }
 

--- a/relay-proxy/test/relayPool.test.js
+++ b/relay-proxy/test/relayPool.test.js
@@ -308,6 +308,105 @@ test("pong reply cancels pong-timeout", async () => {
   pool.shutdown();
 });
 
+test("evicts a relay that never reaches open after maxFailuresWithoutSuccess closes", async () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    reconnectInitialMs: 5,
+    reconnectMaxMs: 10,
+    maxFailuresWithoutSuccess: 3,
+  });
+  pool.addRelay("wss://dead");
+  // Three sequential closes WITHOUT any open in between — simulates a
+  // relay that returns 403/502 at the WS handshake every time.
+  factory.sockets[0].emit("close");
+  await new Promise((r) => setTimeout(r, 15));
+  factory.sockets[1].emit("close");
+  await new Promise((r) => setTimeout(r, 15));
+  factory.sockets[2].emit("close");
+  await new Promise((r) => setTimeout(r, 30));
+  const state = pool.getState("wss://dead");
+  assert.equal(state.evicted, true, "should be marked evicted");
+  assert.equal(state.failures, 3);
+  assert.equal(state.successfulOpens, 0);
+  // No further reconnect after eviction
+  const socketsAtEviction = factory.sockets.length;
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(factory.sockets.length, socketsAtEviction, "no reconnect after eviction");
+});
+
+test("does NOT evict a relay that has reached open at least once, even with many failures", async () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    reconnectInitialMs: 5,
+    reconnectMaxMs: 10,
+    maxFailuresWithoutSuccess: 2,
+  });
+  pool.addRelay("wss://flaky");
+  factory.sockets[0]._openFromServer(); // one successful open
+  factory.sockets[0].emit("close");
+  await new Promise((r) => setTimeout(r, 15));
+  factory.sockets[1].emit("close"); // never opens
+  await new Promise((r) => setTimeout(r, 15));
+  factory.sockets[2].emit("close"); // never opens
+  await new Promise((r) => setTimeout(r, 30));
+  const state = pool.getState("wss://flaky");
+  assert.equal(state.evicted, false, "should NOT be evicted — had a successful open");
+  assert.ok(state.successfulOpens >= 1);
+});
+
+test("addRelay on evicted entry just bumps refCount, does not reopen", async () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    reconnectInitialMs: 5,
+    reconnectMaxMs: 10,
+    maxFailuresWithoutSuccess: 2,
+  });
+  pool.addRelay("wss://dead");
+  factory.sockets[0].emit("close");
+  await new Promise((r) => setTimeout(r, 15));
+  factory.sockets[1].emit("close");
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(pool.getState("wss://dead").evicted, true);
+  const socketCountBefore = factory.sockets.length;
+  pool.addRelay("wss://dead"); // second pair tries to use same URL
+  assert.equal(pool.getState("wss://dead").refCount, 2);
+  assert.equal(factory.sockets.length, socketCountBefore, "no new socket for evicted URL");
+});
+
+test("releaseRelay on evicted entry decrements; entry is removed at refCount=0 (next addRelay retries from scratch)", async () => {
+  const factory = makeFactory();
+  const { createRelayPool } = require("../relayPool");
+  const pool = createRelayPool({
+    createSocket: factory,
+    signerPubkeysProvider: () => ["s1"],
+    reconnectInitialMs: 5,
+    reconnectMaxMs: 10,
+    maxFailuresWithoutSuccess: 2,
+  });
+  pool.addRelay("wss://dead");
+  factory.sockets[0].emit("close");
+  await new Promise((r) => setTimeout(r, 15));
+  factory.sockets[1].emit("close");
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(pool.getState("wss://dead").evicted, true);
+  pool.releaseRelay("wss://dead");
+  assert.equal(pool.getState("wss://dead"), null, "evicted entry removed when refCount reaches 0");
+  // A fresh addRelay creates a brand-new entry that gives the relay another chance
+  pool.addRelay("wss://dead");
+  const fresh = pool.getState("wss://dead");
+  assert.equal(fresh.evicted, false, "new entry starts un-evicted");
+  assert.equal(fresh.failures, 0, "new entry starts with zero failures");
+});
+
 test("heartbeat stops on release", async () => {
   const factory = makeFactory();
   const { createRelayPool } = require("../relayPool");


### PR DESCRIPTION
## Summary

Adds a `maxFailuresWithoutSuccess` threshold to the relay pool's reconnect loop so relays that are permanently broken from this proxy's perspective (e.g. `wss://nostr.wine` 403 / NIP-42-AUTH-required, `wss://garden.zap.cooking/` 502 / down-for-months) are released from active reconnection after N failures with zero successful opens.

## Why now

Inspecting the proxy state during today's Wisp diagnostic session surfaced two stale entries with 500+ cumulative failures each:

```
[RelayPool] wss://nostr.wine/         error: Unexpected server response: 403
[RelayPool] wss://nostr.wine/         reconnecting in 600000ms (failures=534)
[RelayPool] wss://garden.zap.cooking/ error: Unexpected server response: 502
[RelayPool] wss://garden.zap.cooking/ reconnecting in 600000ms (failures=533)
```

Both will never recover (Clave doesn't implement NIP-42 AUTH; garden.zap.cooking has been 502 for months). They sit in the pool because old `clients.json` entries still reference them in their URI relay sets, and the current code retries indefinitely.

## How it works

- New per-entry counter `successfulOpens` (incremented when WS reaches `open` state)
- New per-entry flag `evicted: false`
- On `close`: after `failures++`, if `failures >= maxFailuresWithoutSuccess && successfulOpens === 0 && !evicted`, mark `evicted: true`, log a warning, and skip `scheduleReconnect`
- `addRelay` on an existing evicted entry: bumps `refCount` but doesn't reopen
- `releaseRelay` on evicted entry: normal flow — when refCount hits 0, entry is removed from the pool
- A future `addRelay` after deletion creates a brand-new un-evicted entry that retries from scratch — so eviction is per-(entry-lifetime), not per-process-lifetime

`successfulOpens === 0` (not `successfulEvents === 0`) is the right criterion — it distinguishes permanently broken relays (403/502 never reach `open`) from healthy-but-quiet relays (open fine, just nobody is signing on them right now).

Default threshold: 10. With the standard backoff (1s, 2s, 4s, …, capped at 600s), 10 failures takes ~17 minutes — long enough to ride out a real outage, short enough to stop wasting resources on a permanent dead relay. Configurable via constructor.

## Test plan

- [x] `node --test relay-proxy/test/relayPool.test.js` — 22/22 pass (4 new cases)
- [x] `node --test relay-proxy/test/` — full 79/79 proxy suite pass
- [ ] Deploy to Dell: `sudo cp relay-proxy/relayPool.js /opt/clave-proxy/ && sudo systemctl restart clave-proxy`
- [ ] Verify post-deploy via `sudo journalctl -u clave-proxy --since "30 min ago" | grep -E "permanently failed|RelayPool"` — expect:
  - within ~17 min, both `nostr.wine` and `garden.zap.cooking/` get a one-time `permanently failed after N attempts (no successful opens) — releasing` line
  - no further reconnect attempts logged for those URLs
  - other healthy relays in pool (powr.build, nos.lol, damus.io, primal.net, bucket.coracle.social, ephemeral.snowflare.cc, relay.nsec.app) keep their reconnect/heartbeat behavior unchanged

## Closes

BACKLOG entry "Proxy secondary-pool max-failures eviction" (opened earlier today during proxy-state inspection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)