### PR TITLE
refactor: extract RelayUtils.swift from AppState (Stage 1)

### DIFF
--- a/Clave.xcodeproj/project.pbxproj
+++ b/Clave.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		DE7E10B3DE7E10B3DE7E10B3 /* DeveloperSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10B1DE7E10B1DE7E10B1 /* DeveloperSettings.swift */; };
 		DE7E10C2DE7E10C2DE7E10C2 /* LogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10C1DE7E10C1DE7E10C1 /* LogExporter.swift */; };
 		DE7E10C3DE7E10C3DE7E10C3 /* LogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10C1DE7E10C1DE7E10C1 /* LogExporter.swift */; };
+		DE7E10C5DE7E10C5DE7E10C5 /* RelayUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10C4DE7E10C4DE7E10C4 /* RelayUtils.swift */; };
 		EF1963B89F3A6472380F1E0A /* LightRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D7A5B2F8BD020005A6545 /* LightRelay.swift */; };
 		EF251FEC744434349FD7256D /* P256K in Frameworks */ = {isa = PBXBuildFile; productRef = EF609A96DAD7E5693CA7EE4D /* P256K */; };
 		EF304CFAA8D958E7CCDF01AD /* LightCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D7A592F8BD020005A6545 /* LightCrypto.swift */; };
@@ -99,6 +100,7 @@
 		C1A4F2B3C5D6E700000010 /* AccountTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountTheme.swift; sourceTree = "<group>"; };
 		DE7E10B1DE7E10B1DE7E10B1 /* DeveloperSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperSettings.swift; sourceTree = "<group>"; };
 		DE7E10C1DE7E10C1DE7E10C1 /* LogExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogExporter.swift; sourceTree = "<group>"; };
+		DE7E10C4DE7E10C4DE7E10C4 /* RelayUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayUtils.swift; sourceTree = "<group>"; };
 		EF3D7A0F2F8BCAE3005A6545 /* Clave.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Clave.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EF3D7A1C2F8BCAE6005A6545 /* ClaveTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ClaveTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EF3D7A262F8BCAE6005A6545 /* ClaveUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ClaveUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -237,6 +239,7 @@
 				EF3D7A5B2F8BD020005A6545 /* LightRelay.swift */,
 				EF3D7A5C2F8BD020005A6545 /* LightSigner.swift */,
 				AE01F2A3B4C5D6E700000004 /* Nip19.swift */,
+				DE7E10C4DE7E10C4DE7E10C4 /* RelayUtils.swift */,
 				EF3D7A5D2F8BD020005A6545 /* SharedConstants.swift */,
 				EF3D7A5E2F8BD020005A6545 /* SharedKeychain.swift */,
 				AE01F2A3B4C5D6E700000007 /* SharedKeychain+Enumeration.swift */,
@@ -447,6 +450,7 @@
 				F60FCE012F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift in Sources */,
 				B0EBA01E2F90AB01000A0001 /* PendingApprovalBanner.swift in Sources */,
 				DE7E10C2DE7E10C2DE7E10C2 /* LogExporter.swift in Sources */,
+				DE7E10C5DE7E10C5DE7E10C5 /* RelayUtils.swift in Sources */,
 				AE01F2A3B4C5D6E700000002 /* ActivitySummary.swift in Sources */,
 				AE01F2A3B4C5D6E700000005 /* Nip19.swift in Sources */,
 				AE01F2A3B4C5D6E700000008 /* SharedKeychain+Enumeration.swift in Sources */,

--- a/Clave/AppState.swift
+++ b/Clave/AppState.swift
@@ -1582,7 +1582,7 @@ final class AppState {
         }
 
         // Connect to every URI relay in parallel, best-effort.
-        let connectedRelays = await connectToRelays(urls: parsedURI.relays, timeout: 10.0)
+        let connectedRelays = await RelayUtils.connectToRelays(urls: parsedURI.relays, timeout: 10.0)
         defer {
             for relay in connectedRelays { relay.disconnect() }
         }
@@ -1641,7 +1641,7 @@ final class AppState {
             if !handshakeComplete,
                let eventData = connectEvent.toJSON().data(using: .utf8),
                let eventDict = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any] {
-                let acceptedCount = await publishEventToRelays(connectedRelays, event: eventDict)
+                let acceptedCount = await RelayUtils.publishEventToRelays(connectedRelays, event: eventDict)
 
                 if !activityLogged {
                     let success = acceptedCount > 0
@@ -1680,7 +1680,7 @@ final class AppState {
                 "since": now - 10,
                 "limit": 10
             ]
-            let events = await fetchEventsFromRelays(connectedRelays, filter: listenFilter, timeout: 3.0)
+            let events = await RelayUtils.fetchEventsFromRelays(connectedRelays, filter: listenFilter, timeout: 3.0)
             for event in events {
                 guard let eventId = event["id"] as? String, seenEventIds.insert(eventId).inserted else { continue }
                 guard let pubkey = event["pubkey"] as? String,
@@ -2258,81 +2258,4 @@ final class AppState {
         }.resume()
     }
 
-    // MARK: - Multi-relay helpers (nostrconnect handshake)
-
-    /// Connect to multiple relays in parallel, best-effort.
-    /// Returns only the relays that connected successfully within the timeout.
-    /// Failures are silently dropped so one unreachable relay never blocks the others.
-    private func connectToRelays(urls: [String], timeout: TimeInterval) async -> [LightRelay] {
-        await withTaskGroup(of: LightRelay?.self) { group in
-            for url in urls {
-                group.addTask {
-                    let relay = LightRelay(url: url)
-                    do {
-                        try await relay.connect(timeout: timeout)
-                        return relay
-                    } catch {
-                        return nil
-                    }
-                }
-            }
-            var connected: [LightRelay] = []
-            for await maybe in group {
-                if let relay = maybe { connected.append(relay) }
-            }
-            return connected
-        }
-    }
-
-    /// Publish the same event to all connected relays in parallel.
-    /// Returns the number of relays that returned `OK true`.
-    private func publishEventToRelays(_ relays: [LightRelay], event: [String: Any]) async -> Int {
-        await withTaskGroup(of: Bool.self) { group in
-            for relay in relays {
-                group.addTask {
-                    (try? await relay.publishEvent(event: event)) ?? false
-                }
-            }
-            var accepted = 0
-            for await ok in group {
-                if ok { accepted += 1 }
-            }
-            return accepted
-        }
-    }
-
-    /// Fetch events matching the filter from all connected relays in parallel.
-    /// Aggregates results; duplicates by event id are NOT removed (caller should handle).
-    private func fetchEventsFromRelays(
-        _ relays: [LightRelay],
-        filter: [String: Any],
-        timeout: TimeInterval
-    ) async -> [[String: Any]] {
-        await withTaskGroup(of: [[String: Any]].self) { group in
-            for relay in relays {
-                group.addTask {
-                    (try? await relay.fetchEvents(filter: filter, timeout: timeout)) ?? []
-                }
-            }
-            var all: [[String: Any]] = []
-            for await events in group {
-                all.append(contentsOf: events)
-            }
-            return all
-        }
-    }
-
-    // MARK: - Test-only shims
-
-    #if DEBUG
-    func _testOnlyConnectToRelays(urls: [String], timeout: TimeInterval) async -> [LightRelay] {
-        await connectToRelays(urls: urls, timeout: timeout)
-    }
-    func _testOnlyPublishEventToRelays(_ relays: [LightRelay], event: [String: Any]) async -> Int {
-        await publishEventToRelays(relays, event: event)
-    }
-    func _testOnlyFetchEventsFromRelays(_ relays: [LightRelay], filter: [String: Any], timeout: TimeInterval) async -> [[String: Any]] {
-        await fetchEventsFromRelays(relays, filter: filter, timeout: timeout)
-    }
-    #endif
 }

--- a/ClaveTests/RelayUtilsTests.swift
+++ b/ClaveTests/RelayUtilsTests.swift
@@ -1,17 +1,15 @@
 import XCTest
 @testable import Clave
 
-final class AppStateMultiRelayHelpersTests: XCTestCase {
+final class RelayUtilsTests: XCTestCase {
 
     func testConnectToRelaysReturnsEmptyForEmptyInput() async {
-        let appState = AppState()
-        let result = await appState._testOnlyConnectToRelays(urls: [], timeout: 1.0)
+        let result = await RelayUtils.connectToRelays(urls: [], timeout: 1.0)
         XCTAssertEqual(result.count, 0)
     }
 
     func testConnectToRelaysSkipsUnreachableURLs() async {
-        let appState = AppState()
-        let result = await appState._testOnlyConnectToRelays(
+        let result = await RelayUtils.connectToRelays(
             urls: ["wss://127.0.0.1:1", "wss://not-a-real-relay.invalid.test"],
             timeout: 1.5
         )
@@ -19,14 +17,12 @@ final class AppStateMultiRelayHelpersTests: XCTestCase {
     }
 
     func testPublishEventToRelaysReturnsZeroForEmptyInput() async {
-        let appState = AppState()
-        let count = await appState._testOnlyPublishEventToRelays([], event: ["kind": 1])
+        let count = await RelayUtils.publishEventToRelays([], event: ["kind": 1])
         XCTAssertEqual(count, 0)
     }
 
     func testFetchEventsFromRelaysReturnsEmptyForEmptyInput() async {
-        let appState = AppState()
-        let events = await appState._testOnlyFetchEventsFromRelays([], filter: [:], timeout: 1.0)
+        let events = await RelayUtils.fetchEventsFromRelays([], filter: [:], timeout: 1.0)
         XCTAssertEqual(events.count, 0)
     }
 }

--- a/Shared/RelayUtils.swift
+++ b/Shared/RelayUtils.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Pure parallel-fanout helpers for multi-relay operations during the nostrconnect handshake.
+///
+/// All three methods are best-effort: failures are silently dropped so one unreachable
+/// relay never blocks the others. Callers that need per-relay status reporting should
+/// extend this namespace (see BACKLOG: "Better error-message detail in nostrconnect Activity log").
+enum RelayUtils {
+
+    /// Connect to multiple relays in parallel, best-effort.
+    /// Returns only the relays that connected successfully within the timeout.
+    /// Failures are silently dropped so one unreachable relay never blocks the others.
+    static func connectToRelays(urls: [String], timeout: TimeInterval) async -> [LightRelay] {
+        await withTaskGroup(of: LightRelay?.self) { group in
+            for url in urls {
+                group.addTask {
+                    let relay = LightRelay(url: url)
+                    do {
+                        try await relay.connect(timeout: timeout)
+                        return relay
+                    } catch {
+                        return nil
+                    }
+                }
+            }
+            var connected: [LightRelay] = []
+            for await maybe in group {
+                if let relay = maybe { connected.append(relay) }
+            }
+            return connected
+        }
+    }
+
+    /// Publish the same event to all connected relays in parallel.
+    /// Returns the number of relays that returned `OK true`.
+    static func publishEventToRelays(_ relays: [LightRelay], event: [String: Any]) async -> Int {
+        await withTaskGroup(of: Bool.self) { group in
+            for relay in relays {
+                group.addTask {
+                    (try? await relay.publishEvent(event: event)) ?? false
+                }
+            }
+            var accepted = 0
+            for await ok in group {
+                if ok { accepted += 1 }
+            }
+            return accepted
+        }
+    }
+
+    /// Fetch events matching the filter from all connected relays in parallel.
+    /// Aggregates results; duplicates by event id are NOT removed (caller should handle).
+    static func fetchEventsFromRelays(
+        _ relays: [LightRelay],
+        filter: [String: Any],
+        timeout: TimeInterval
+    ) async -> [[String: Any]] {
+        await withTaskGroup(of: [[String: Any]].self) { group in
+            for relay in relays {
+                group.addTask {
+                    (try? await relay.fetchEvents(filter: filter, timeout: timeout)) ?? []
+                }
+            }
+            var all: [[String: Any]] = []
+            for await events in group {
+                all.append(contentsOf: events)
+            }
+            return all
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Stage 1 of the [AppState god-object split](https://github.com/DocNR/clave/blob/main/BACKLOG.md) — extracts three pure parallel-fanout helpers (`connectToRelays`, `publishEventToRelays`, `fetchEventsFromRelays`) plus their `_testOnly*` DEBUG shims out of `Clave/AppState.swift` into a new `Shared/RelayUtils.swift` namespace. Zero behavior change.

## Why this stage first

- Lowest-risk extraction in the 4-stage plan: methods are already pure (no `self.` references), already side-effect-free, already covered by unit tests.
- Establishes the extraction pattern (caseless `enum` namespace, matching `Shared/LogExporter.swift` precedent) for the higher-risk stages that follow.
- AppState.swift drops from 2,338 → 2,260 LOC — small absolute win, but the ratio of surface area to risk is the cleanest of the four stages.

## Design decisions (locked during brainstorm)

| Decision | Choice | Reasoning |
|---|---|---|
| Type shape | Caseless `enum RelayUtils` with `static` methods | Matches `LogExporter.swift` precedent; uninstantiable namespace |
| `_testOnly*` wrappers | Dropped | Existed only because originals were `private`; with extraction the methods are internal-by-default |
| Actor isolation | None (plain `static func ... async`) | Matches today's behavior; `LightRelay` is already `@unchecked Sendable` |
| Logger category | None | Stage 1 is structural-only; richer per-relay error reporting belongs in the existing BACKLOG follow-up |
| Test file naming | Renamed `AppStateMultiRelayHelpersTests` → `RelayUtilsTests` | Matches Clave's "what's tested" convention |

## What changed

- **NEW** `Shared/RelayUtils.swift` (71 LOC) — caseless `enum` namespace with the three `static` async methods. Function bodies and doc comments preserved byte-for-byte.
- **EDIT** `Clave/AppState.swift` — deleted lines 2261–2337 (the `// MARK: - Multi-relay helpers` section + `#if DEBUG` test shims); updated 3 call sites in `handleNostrConnect` from `connectToRelays(...)` → `RelayUtils.connectToRelays(...)`, etc.
- **RENAME + EDIT** `ClaveTests/AppStateMultiRelayHelpersTests.swift` → `ClaveTests/RelayUtilsTests.swift` — 4 tests, same assertions, dropped the now-unnecessary `let appState = AppState()` setup line.
- **EDIT** `Clave.xcodeproj/project.pbxproj` — 4 entries added for `RelayUtils.swift` (Clave target only, NSE excluded since the methods are nostrconnect-handshake helpers, not signing-path code).

## What this PR does NOT change

- Behavior, returns, swallowed errors, parallelism, actor isolation
- Logging (none added)
- Other files in `Shared/` or `Clave/`
- Migration-related code in `AppState`
- Stages 2/3/4 of the split (`LegacyMigrations`, `ProfileFetcher`, `NostrConnectCoordinator`, `ProxyClient`, `AccountManager`, `PendingApprovalCoordinator` — each gets its own PR)
- Build number (separate PR after merge per recent #27/#28 convention)

## Test plan

- [x] `xcodebuild test -scheme Clave -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -skip-testing:ClaveUITests` on `main`: **240 passed / 0 failed** ✅
- [x] Same command on `refactor/relay-utils`: **240 passed / 0 failed** ✅ (identical count; new `RelayUtilsTests` class replaces `AppStateMultiRelayHelpersTests` 1:1 with same 4 tests)
- [x] Visual diff: only deletions in the multi-relay helpers section + 3 1-line call-site edits. No surrounding code touched.
- [ ] Build 64 archive + on-device noStrudel control trace (gated on this PR + the follow-up pbxproj-bump PR landing)

## Follow-up PR

`chore: bump pbxproj to build 64` — separate PR after this one merges, matching the #27/#28 pattern. Build 64 internal-TF only; on-device verification with the new `[Pair]` log category from #27 will confirm no nostrconnect handshake regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)