### PR TITLE
fix: nostrconnect connect-flow polish (same-device overlay copy + QR rescan dedup)

### DIFF
--- a/Clave/Views/Home/Connect/ConnectNostrconnectTabView.swift
+++ b/Clave/Views/Home/Connect/ConnectNostrconnectTabView.swift
@@ -39,6 +39,16 @@ struct ConnectNostrconnectTabView: View {
     @State private var cameraAuthState: AVAuthorizationStatus = .notDetermined
     @State private var isScanning = true
     @State private var scanError: String?
+    /// Last QR code value we accepted via the scanner. The scanner auto-
+    /// resumes when ApprovalSheet dismisses (so the user can scan a
+    /// different QR after a mis-scan), but the same QR is almost always
+    /// still in frame and gets re-detected within ~1s, looping the user
+    /// back into ApprovalSheet they just dismissed. We dedup against this
+    /// value to break the loop. A different QR has a different code
+    /// (each nostrconnect URI carries a fresh secret) so legitimate
+    /// retries with a new code aren't blocked. Cleared when this view
+    /// re-mounts (i.e. ConnectSheet is reopened).
+    @State private var lastAcceptedScanCode: String?
 
     var body: some View {
         ScrollView {
@@ -240,9 +250,18 @@ struct ConnectNostrconnectTabView: View {
         // duplicate onParsed invocations.
         guard isScanning else { return }
         let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Dedup against the last accepted QR. After ApprovalSheet
+        // dismisses, parsedURI flips back to nil and the onChange above
+        // re-arms the scanner — but the QR is almost always still in
+        // frame, so without this guard the user gets bounced straight
+        // back into ApprovalSheet for the same URI they just cancelled.
+        // A new client URI has a new secret (and therefore a new code),
+        // so legitimate retries from a different source aren't blocked.
+        if trimmed == lastAcceptedScanCode { return }
         do {
             let parsed = try NostrConnectParser.parse(trimmed)
             isScanning = false
+            lastAcceptedScanCode = trimmed
             UINotificationFeedbackGenerator().notificationOccurred(.success)
             onParsed(parsed, .qrScan)
         } catch let error as NostrConnectParser.ParseError {

--- a/Clave/Views/Home/Connect/ConnectNostrconnectTabView.swift
+++ b/Clave/Views/Home/Connect/ConnectNostrconnectTabView.swift
@@ -1,6 +1,19 @@
 import SwiftUI
 import AVFoundation
 
+/// How a nostrconnect URI was acquired in the Connect flow. Drives the
+/// post-Approve "Connecting…" overlay copy: paste implies the client
+/// app is on the same device (user copied the URI here), so the user
+/// should switch back to it during the handshake; a QR scan implies
+/// the client is on another screen, so staying foregrounded in Clave
+/// is fine. Background: iOS suspends the client app's WebSocket
+/// subscription once it loses foreground, so a same-device user who
+/// follows "stay in Clave" advice never receives the connect-response.
+enum NostrConnectURISource {
+    case paste
+    case qrScan
+}
+
 /// Body of the "Nostrconnect" tab in ConnectSheet. Composes a live camera
 /// viewfinder + a paste field + a help link. The camera permission denial
 /// path renders an inline placeholder with an "Open Settings" link;
@@ -18,7 +31,7 @@ struct ConnectNostrconnectTabView: View {
     /// because .onAppear doesn't re-fire (the view never unmounts —
     /// the segmented control swaps body inline rather than pushing).
     let parsedURI: NostrConnectParser.ParsedURI?
-    let onParsed: (NostrConnectParser.ParsedURI) -> Void
+    let onParsed: (NostrConnectParser.ParsedURI, NostrConnectURISource) -> Void
 
     @State private var pasteText = ""
     @State private var pasteError: String?
@@ -202,7 +215,7 @@ struct ConnectNostrconnectTabView: View {
         do {
             let parsed = try NostrConnectParser.parse(trimmed)
             pasteError = nil
-            onParsed(parsed)
+            onParsed(parsed, .paste)
         } catch {
             pasteError = "That doesn't look like a valid nostrconnect URI."
         }
@@ -231,7 +244,7 @@ struct ConnectNostrconnectTabView: View {
             let parsed = try NostrConnectParser.parse(trimmed)
             isScanning = false
             UINotificationFeedbackGenerator().notificationOccurred(.success)
-            onParsed(parsed)
+            onParsed(parsed, .qrScan)
         } catch let error as NostrConnectParser.ParseError {
             switch error {
             case .invalidScheme: scanError = "Not a Nostrconnect code"

--- a/Clave/Views/Home/Connect/ConnectSheet.swift
+++ b/Clave/Views/Home/Connect/ConnectSheet.swift
@@ -19,6 +19,11 @@ struct ConnectSheet: View {
 
     @State private var selectedTab: Tab = .bunker
     @State private var parsedURI: NostrConnectParser.ParsedURI?
+    /// Source of the most recent parsed URI. Drives the "Connecting…"
+    /// overlay copy — paste implies same-device pairing (switch back to
+    /// the client app), QR implies cross-device (stay in Clave). Default
+    /// is overwritten by handleParsed before isConnecting ever flips.
+    @State private var lastParsedSource: NostrConnectURISource = .paste
     @State private var isConnecting = false
     @State private var connectionError: String?
 
@@ -76,7 +81,20 @@ struct ConnectSheet: View {
     }
 
     private var connectingOverlay: some View {
-        ZStack {
+        // Same-device (paste): the client app is on this device but iOS
+        // suspends its WebSocket subscription as soon as it loses
+        // foreground, so the user must switch back to it for the client
+        // to receive Clave's connect-response. UIBackgroundTask in
+        // submitApproval keeps Clave running for the ~15s handshake
+        // window. Cross-device (QR): there's no client app to return to
+        // on this device, so the original "stay in Clave" copy applies.
+        let subtitle: String = switch lastParsedSource {
+        case .paste:
+            "Switch back to your client app to finish connecting. Clave keeps running in the background."
+        case .qrScan:
+            "Stay in Clave for a few seconds"
+        }
+        return ZStack {
             Color.black.opacity(0.4).ignoresSafeArea()
             VStack(spacing: 16) {
                 ProgressView().controlSize(.large)
@@ -84,7 +102,7 @@ struct ConnectSheet: View {
                     Text("Connecting...")
                         .font(.headline)
                         .foregroundStyle(.white)
-                    Text("Stay in Clave for a few seconds")
+                    Text(subtitle)
                         .font(.subheadline)
                         .foregroundStyle(.white.opacity(0.85))
                         .multilineTextAlignment(.center)
@@ -95,8 +113,9 @@ struct ConnectSheet: View {
         }
     }
 
-    private func handleParsed(_ uri: NostrConnectParser.ParsedURI) {
+    private func handleParsed(_ uri: NostrConnectParser.ParsedURI, source: NostrConnectURISource) {
         parsedURI = uri
+        lastParsedSource = source
     }
 
     private func submitApproval(uri: NostrConnectParser.ParsedURI,

--- a/docs/nip46-compatibility.md
+++ b/docs/nip46-compatibility.md
@@ -1,6 +1,6 @@
 # NIP-46 Client Compatibility (Clave)
 
-_Last updated: 2026-04-29 — statuses reflect Clave build 29 unless noted otherwise._
+_Last updated: 2026-05-07 — statuses reflect Clave build 29 unless noted otherwise. iOS same-device timing section verified on build 66._
 
 This document tracks how Nostr clients interoperate with Clave's NIP-46 signer. It is **Clave-centric**: every status row reflects what we have actually tested against Clave specifically. Other NIP-46 signers (Amber, nsec.app, etc.) may behave differently with the same client.
 
@@ -12,6 +12,70 @@ When a client doesn't work, we try to attribute the issue to one of four buckets
 - **spec-ambiguity** — the NIP-46 spec permits both behaviors and the two implementations chose differently.
 
 The triage guide below has more detail on how to tell these apart — and why "the bug isn't in our signer" is harder to prove than it sounds.
+
+Before the per-client matrix, see [iOS same-device pairing](#ios-same-device-pairing) below — for client and signer running on the same iOS device, prefer Clave's `bunker://` URI; same-device `nostrconnect://` hits a fundamental WebSocket suspension constraint.
+
+---
+
+## iOS same-device pairing
+
+**Recommendation: prefer Clave's `bunker://` URI for same-device pairing on iOS.** Same-device `nostrconnect://` hits a fundamental iOS WebSocket suspension constraint that no signer-side fix can route around — Clave's own background-task work in [PR #26](https://github.com/DocNR/clave/pull/26) (build 62) protects Clave's publish side, but the client app's receive side is its own problem and most iOS clients haven't solved it.
+
+For other configurations — cross-device pairing (Clave on iPhone; client on web, desktop, or Android), or non-iOS clients in general — `nostrconnect://` is fine and is often the better UX. The constraint below applies specifically when client and signer both run on the same iOS device.
+
+Verified on Clave build 66 against [noStrudel](https://nostrudel.ninja) and [Jumble](https://github.com/CodyTseng/jumble).
+
+### Why `bunker://` works on same-device iOS
+
+The bunker flow does not require the user to background the client app:
+
+1. User opens the client (foreground; WebSocket subscription alive).
+2. User pastes Clave's `bunker://` URI into the client (clipboard, Universal Link, or QR scan).
+3. Client publishes a `connect` RPC to `wss://relay.powr.build/` (the relay embedded in Clave's bunker URI).
+4. Clave's relay proxy catches the RPC on its primary subscription and wakes Clave's Notification Service Extension via APNs. Clave does not need to be in the foreground.
+5. Clave decrypts, prompts the user, and publishes the connect-response back to `relay.powr.build`.
+6. The client's still-foregrounded subscription receives the response.
+
+The wake-up across the system boundary is **Clave's problem**, and Clave solves it via its proxy + NSE architecture. The client app is never asked to survive being backgrounded.
+
+### Why `nostrconnect://` is brittle on same-device iOS
+
+The nostrconnect flow inverts the responsibility — wake-up becomes **the client's problem**. The user must paste the nostrconnect URI into Clave, which means switching apps mid-handshake:
+
+1. User opens client; client generates a `nostrconnect://` URI and opens a subscription on the URI's relays to await the connect-response.
+2. User copies the URI and switches to Clave (the client is now backgrounded).
+3. User pastes and approves in Clave; Clave publishes the connect-response.
+4. **The client's WebSocket subscription must be alive when the relay forwards the event** — otherwise the response is dropped.
+
+iOS does not cooperate with step 4. Within roughly 5–10 seconds of being backgrounded, an app's `URLSessionWebSocketTask` subscriptions are frozen. The app is still resident in memory but the subscription stops receiving relay traffic. APNs is bundle-ID-scoped, so Clave cannot push the client awake the way Clave is itself wakeable — there is no signer-side equivalent of the bunker flow's NSE wake.
+
+Two implementation details in `nostr-tools` (the library most iOS-relevant clients use) make the failure permanent rather than recoverable:
+
+- The handshake subscription uses `limit: 0` ([nip46.ts:201](https://github.com/nbd-wtf/nostr-tools/blob/v2.23.0/nip46.ts#L201)), telling the relay "no stored events" — only events forwarded *after* the subscription was opened are delivered. If the WebSocket is frozen during the connect-response forward and later resumes, the event is gone; the relay will not replay it.
+- If iOS terminates the WebSocket entirely (deeper background or memory pressure), the subscription's `onclose` rejects with `subscription closed before connection was established` ([nip46.ts:230-232](https://github.com/nbd-wtf/nostr-tools/blob/v2.23.0/nip46.ts#L230-L232)) — well before the library's 5-minute `maxWait` timer.
+
+End result: the user lands back in the client expecting pairing to have completed, and instead sees either a stalled spinner (up to 5 minutes) or an opaque close error.
+
+### If you must support `nostrconnect://` on iOS same-device
+
+These mitigations help but none fully closes the gap:
+
+- **Wrap your handshake subscription in `UIApplication.beginBackgroundTask(withName:expirationHandler:)`** — buys ~30 seconds of guaranteed background runtime, mirroring Clave's own publish-side fix. Addresses the fast-suspension case but not extended trips into Clave or backgrounding under memory pressure.
+- **Re-subscribe with a `since` cursor on `scenePhase` foreground transitions** rather than `limit: 0`, so the relay replays any matching event published while you were suspended. Works only if the relay retains recent events for replay — strfry-based relays do; others may not.
+- **Surface UI guidance to the user**: "Return to <client> after approving in Clave." Combined with Clave's "Stay in Clave for a few seconds" overlay (build 62+), the user understands the handshake window has two ends and either side can lose it.
+- **Test same-device pairing as a first-class scenario**, not as an edge case. Cross-device flows (Clave on iPhone, client on web/desktop) do not exhibit this constraint and won't surface it during development.
+
+---
+
+## Improving post-pair delivery reliability for Clave-paired clients
+
+Independent of the pairing-mode discussion above, and applicable to all clients regardless of platform: clients can substantially improve their wake-up reliability for Clave by including `wss://relay.powr.build/` in their `nostrconnect://` URI's `relay=` parameters.
+
+Why: Clave's relay proxy (`proxy.clave.casa`) maintains a persistent **primary subscription** on `relay.powr.build`, narrow-filtered by `#p` to paired Clave signer pubkeys. Any kind:24133 event addressed to a paired Clave signer on that relay is caught by the proxy and delivered via APNs to wake Clave's Notification Service Extension — regardless of whether Clave is in the foreground.
+
+When the client publishes a `sign_event` RPC to `relay.powr.build`, the proxy catches it on the primary subscription immediately. No dependency on the proxy's secondary-relay pool being warmed up for whichever relay the client picked; no waiting on Clave's own foreground subscription. Clave's `bunker://` URIs already embed `relay.powr.build` for exactly this reason — and the proxy primary-sub catch is part of why bunker pairings tend to be more reliable than nostrconnect, not just on iOS.
+
+Note: this benefits the **client → Clave** direction (delivery to Clave). It does not change the **Clave → client** direction (delivery of signed responses back to the client), which is still subject to whatever the client's own subscription does. In particular, it does not mitigate the iOS handshake-window issue described above — that's a different problem on the other side of the channel.
 
 ---
 
@@ -269,6 +333,7 @@ Open a PR that:
 
 | Date | Change |
 |---|---|
+| 2026-05-07 | Added "iOS same-device pairing" section (recommends `bunker://` for same-device iOS, explains the nostrconnect WebSocket suspension constraint). Added "Improving post-pair delivery reliability for Clave-paired clients" section (recommends `wss://relay.powr.build/` in nostrconnect URI relay sets for client→Clave wake-up). Clave-side handshake protection in [PR #26](https://github.com/DocNR/clave/pull/26) / build 62; verified on build 66 against [noStrudel](https://nostrudel.ninja) and [Jumble](https://github.com/CodyTseng/jumble). |
 | 2026-04-29 | Initial publication. Build 29. |
 
 ---

--- a/docs/nip46-compatibility.md
+++ b/docs/nip46-compatibility.md
@@ -56,6 +56,8 @@ Two implementation details in `nostr-tools` (the library most iOS-relevant clien
 
 End result: the user lands back in the client expecting pairing to have completed, and instead sees either a stalled spinner (up to 5 minutes) or an opaque close error.
 
+Routing the URI through Clave's Universal Link form (`https://clave.casa/connect/?uri=...`) does not change this. iOS backgrounds the source app of a Universal Link tap the same way it backgrounds any app-switch — no extra runtime is granted to the listener. The Universal Link form is worth supporting for UX and to avoid `nostrconnect://` scheme-squatting from other apps that register the scheme, but it does not extend the listener's WebSocket lifetime.
+
 ### If you must support `nostrconnect://` on iOS same-device
 
 These mitigations help but none fully closes the gap:


### PR DESCRIPTION
Two related connect-flow polish bugs surfaced during build 66 verification, both contained to `ConnectNostrconnectTabView.swift` (+ overlay copy in `ConnectSheet.swift`).

## 1. Misleading "Stay in Clave" overlay for same-device nostrconnect

The overlay shipped in build 62 ([PR #26](https://github.com/DocNR/clave/pull/26)) is actively misleading for **same-device** nostrconnect pairs — iOS suspends the client app's WebSocket subscription as soon as it loses foreground, so users who follow that advice never receive the connect-response Clave publishes. Quick-switching back to the client app is what actually completes the handshake. Verified on build 66 against [noStrudel](https://nostrudel.ninja) and [Jumble](https://github.com/CodyTseng/jumble).

Switch the overlay subtitle based on URI provenance:
- paste/text-field → same-device → **"Switch back to your client app to finish connecting. Clave keeps running in the background."**
- QR scan → cross-device (camera scanned another screen) → **keep "Stay in Clave for a few seconds"**.

## 2. QR scanner re-fires the same code after ApprovalSheet cancel

When the user scans a nostrconnect QR, ApprovalSheet presents and the scanner stops. Cancelling ApprovalSheet flips `parsedURI` back to nil and the existing `onChange` handler re-arms the scanner so a different QR can be scanned without closing+reopening the sheet. But the QR the user just scanned is almost always still in frame — within ~1s the AVFoundation pipeline detects it again, looping the user straight back into ApprovalSheet they just dismissed.

Dedup at `handleScannedCode` against a per-mount `lastAcceptedScanCode`. Each nostrconnect URI carries a fresh secret, so different sources produce different codes and legitimate retries pass through. State clears when this view re-mounts (i.e. ConnectSheet is reopened).

## Why provenance is plumbed at the parse callback, not in `AppState`

The "Connecting…" overlay is only rendered in [`ConnectSheet.connectingOverlay`](https://github.com/DocNR/clave/blob/same-device-overlay-copy/Clave/Views/Home/Connect/ConnectSheet.swift) — i.e. the in-app paste/QR-scan flow. The deeplink path in `HomeView` (`pendingNostrconnectURI` → `deeplinkApprovalURI`) runs `appState.handleNostrConnect` in a fire-and-forget `Task` with no progress UI, so it doesn't need a same-device flag. The provenance distinction is added as a top-level `NostrConnectURISource` enum in `ConnectNostrconnectTabView.swift` and threaded through the `onParsed` callback into ConnectSheet's `lastParsedSource` state — no `AppState` changes, no protocol changes.

## Bundles `docs/nip46-compatibility.md` updates

The doc edit was already in the working tree from earlier today's verification work and explains the exact iOS WebSocket suspension constraint this code change addresses (same 2026-05-07 date stamp, same build-66 verification). Shipping them together keeps the public-facing explanation and the in-app UX consistent in one atomic change.

- Added "iOS same-device pairing" section recommending `bunker://` for same-device iOS pairing; explains why `nostrconnect://` is brittle there with `nostr-tools` `limit: 0` + frozen-WebSocket details; lists mitigations for clients that want to support it.
- Added "Improving post-pair delivery reliability for Clave-paired clients" note recommending `wss://relay.powr.build/` in nostrconnect URI relay sets so client→Clave RPCs catch on the proxy's primary subscription regardless of foreground state.

## Out of scope

- Auto-dismissing the overlay early when the handshake reports success — would require surfacing a "first response received" callback from `handleNostrConnect`, and the overlay is rarely seen past ~3s anyway because the user has already switched to the client app. Skip.
- Adding a progress overlay to the deeplink path in `HomeView`. Different code path, separate UX call. Skip.
- Reframing the Connect tab UX to steer same-device users away from nostrconnect entirely (e.g. "Recommended for same-device" hint on Bunker, or a topology-first picker). Worth doing — separate sprint, will brainstorm next.
- Stage 3b/3c god-object refactor — explicitly decoupled.

## Test plan

**Same-device overlay copy**
- [ ] Install build with this change on iPhone.
- [ ] Open noStrudel (same-device, iOS Safari/standalone), generate a `nostrconnect://` URI, copy it.
- [ ] Open Clave → Connect a Client → Nostrconnect tab → tap "Paste Nostrconnect URI" → approve.
- [ ] Confirm overlay subtitle reads **"Switch back to your client app to finish connecting. Clave keeps running in the background."**
- [ ] Quick-switch to noStrudel, confirm pairing completes.
- [ ] Repeat with Jumble.
- [ ] (Optional) Repeat with QR-scan path against a cross-device client (e.g. desktop nostrudel showing a QR), confirm overlay still says **"Stay in Clave for a few seconds"**.

**QR rescan dedup**
- [ ] On a different device, generate a nostrconnect QR (any web client). Point Clave's nostrconnect tab camera at it.
- [ ] Confirm ApprovalSheet appears.
- [ ] Tap Cancel on ApprovalSheet — keep the QR in frame.
- [ ] Confirm camera viewfinder is live (not frozen) but ApprovalSheet does NOT re-present for the same QR.
- [ ] Generate a new QR (refresh client) — confirm new QR scans normally.

**Build / unit tests**
- [x] `xcodebuild test -scheme Clave` — all suites pass on iPhone 17 sim (run on first commit; QR fix is a strict superset and has no test impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)