### PR TITLE
chore: remove dead petname code from Account model

### DIFF
--- a/Clave/AppState+ProfileFetcher.swift
+++ b/Clave/AppState+ProfileFetcher.swift
@@ -29,7 +29,6 @@ extension AppState {
               let idx = accounts.firstIndex(where: { $0.pubkeyHex == pk }) else { return }
         accounts[idx] = Account(
             pubkeyHex: accounts[idx].pubkeyHex,
-            petname: accounts[idx].petname,
             addedAt: accounts[idx].addedAt,
             profile: profile
         )
@@ -141,7 +140,6 @@ extension AppState {
                 // Non-current account: update the accounts array in-place.
                 self.accounts[idx] = Account(
                     pubkeyHex: self.accounts[idx].pubkeyHex,
-                    petname: self.accounts[idx].petname,
                     addedAt: self.accounts[idx].addedAt,
                     profile: cached
                 )

--- a/Clave/AppState.swift
+++ b/Clave/AppState.swift
@@ -32,7 +32,7 @@ final class AppState {
 
     /// All accounts owned by this device. Populated by `loadAccounts()` from
     /// `accountsKey` UserDefaults; mutated by `addAccount` /
-    /// `generateAccount` / `deleteAccount` / `renamePetname`.
+    /// `generateAccount` / `deleteAccount`.
     var accounts: [Account] = []
 
     /// The current account scope for the UI. Stays synchronized with
@@ -407,7 +407,7 @@ final class AppState {
 
         let now = Date().timeIntervalSince1970
         let recovered = pubkeys.map {
-            Account(pubkeyHex: $0, petname: nil, addedAt: now, profile: nil)
+            Account(pubkeyHex: $0, addedAt: now, profile: nil)
         }
         persistAccountsList(recovered)
         // First pubkey becomes current. User can switch via UI later.
@@ -496,7 +496,7 @@ final class AppState {
     /// is added twice, switches to the existing account and returns it
     /// (matches noauth's silent dedupe; Phase 2 UI surfaces a toast).
     @discardableResult
-    func addAccount(nsec: String, petname: String? = nil) throws -> Account {
+    func addAccount(nsec: String) throws -> Account {
         let trimmed = nsec.trimmingCharacters(in: .whitespacesAndNewlines)
         let keys = try Keys.parse(secretKey: trimmed)
         let bech32 = try keys.secretKey().toBech32()
@@ -519,10 +519,8 @@ final class AppState {
         // get written.
         try SharedKeychain.saveNsec(bech32, for: pubkeyHex)
 
-        let sanitizedPetname = sanitizePetname(petname)
         let account = Account(
             pubkeyHex: pubkeyHex,
-            petname: sanitizedPetname,
             addedAt: Date().timeIntervalSince1970,
             profile: nil
         )
@@ -549,10 +547,10 @@ final class AppState {
 
     /// Generate a fresh keypair as a new account.
     @discardableResult
-    func generateAccount(petname: String? = nil) throws -> Account {
+    func generateAccount() throws -> Account {
         let keys = Keys.generate()
         let bech32 = try keys.secretKey().toBech32()
-        return try addAccount(nsec: bech32, petname: petname)
+        return try addAccount(nsec: bech32)
     }
 
     /// Delete an account from this device. Audit 2026-04-30 finding A2:
@@ -636,33 +634,6 @@ final class AppState {
         }
     }
 
-    /// Edit the petname for an account. Audit 2026-04-30 finding A3:
-    /// trim whitespace + strip newlines + cap at 64 chars to prevent
-    /// control-char injection into log lines / notification bodies and
-    /// DoS via huge strings.
-    func renamePetname(for pubkey: String, to petname: String?) {
-        guard let idx = accounts.firstIndex(where: { $0.pubkeyHex == pubkey }) else { return }
-        accounts[idx] = Account(
-            pubkeyHex: accounts[idx].pubkeyHex,
-            petname: sanitizePetname(petname),
-            addedAt: accounts[idx].addedAt,
-            profile: accounts[idx].profile
-        )
-        persistAccounts()
-        if currentAccount?.pubkeyHex == pubkey {
-            currentAccount = accounts[idx]
-        }
-    }
-
-    private func sanitizePetname(_ petname: String?) -> String? {
-        guard let petname else { return nil }
-        let normalized = petname
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .filter { !$0.isNewline }
-        let capped = String(normalized.prefix(64))
-        return capped.isEmpty ? nil : capped
-    }
-
     func rotateBunkerSecret() {
         guard !signerPubkeyHex.isEmpty else { return }
         _ = SharedStorage.rotateBunkerSecret(for: signerPubkeyHex)
@@ -674,11 +645,11 @@ final class AppState {
     // directly.
 
     func importKey(nsec: String) throws {
-        _ = try addAccount(nsec: nsec, petname: nil)
+        _ = try addAccount(nsec: nsec)
     }
 
     func generateKey() throws {
-        _ = try generateAccount(petname: nil)
+        _ = try generateAccount()
     }
 
     func deleteKey() {

--- a/Clave/Views/Home/AddAccountSheet.swift
+++ b/Clave/Views/Home/AddAccountSheet.swift
@@ -103,9 +103,9 @@ struct AddAccountSheet: View {
         do {
             switch mode {
             case .generate:
-                _ = try appState.generateAccount(petname: nil)
+                _ = try appState.generateAccount()
             case .paste:
-                _ = try appState.addAccount(nsec: trimmedNsec, petname: nil)
+                _ = try appState.addAccount(nsec: trimmedNsec)
             }
             UINotificationFeedbackGenerator().notificationOccurred(.success)
             dismiss()

--- a/Clave/Views/Home/Connect/ConnectAccountContextBar.swift
+++ b/Clave/Views/Home/Connect/ConnectAccountContextBar.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-/// Small "Connecting to @petname" bar shown at the top of each focused
+/// Small "Connecting to @<account>" bar shown at the top of each focused
 /// connect view (Show QR / Scan / Paste). Mini themed dot matches the
-/// active account's AccountTheme; reads displayLabel for the petname.
+/// active account's AccountTheme; reads displayLabel for the label.
 ///
 /// Per design-system.md treatment C — sits in the identity zone with
 /// theme-derived accent. Never tappable.

--- a/Clave/Views/Home/SigningAsHeader.swift
+++ b/Clave/Views/Home/SigningAsHeader.swift
@@ -5,8 +5,7 @@ import SwiftUI
 /// account when multi-account is active.
 ///
 /// Looks up the account from a pubkey hex (typically request.signerPubkeyHex);
-/// falls back to a truncated pubkey when no Account / petname / displayName
-/// is available.
+/// falls back to a truncated pubkey when no Account / displayName is available.
 struct SigningAsHeader: View {
     @Environment(AppState.self) private var appState
     let signerPubkeyHex: String

--- a/Clave/Views/Home/SlimIdentityBar.swift
+++ b/Clave/Views/Home/SlimIdentityBar.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 /// Themed mini-banner identity row below AccountStripView. Solid gradient
 /// background (matches AccountDetailView's full-bleed banner in miniature),
-/// mini avatar, @petname, npub, copy button, chevron. Tap anywhere on the row
-/// pushes AccountDetailView for the current account — same path the active-pill
-/// tap uses, via `appState.pendingDetailPubkey`.
+/// mini avatar, displayLabel, npub, copy button, chevron. Tap anywhere on the
+/// row pushes AccountDetailView for the current account — same path the
+/// active-pill tap uses, via `appState.pendingDetailPubkey`.
 ///
 /// 2026-05-02 redesign: replaces the build-38 wash + accent-stroke treatment
 /// with a solid theme gradient for visual continuity with the detail view.

--- a/Clave/Views/Settings/MultiAccountDiagnosticsView.swift
+++ b/Clave/Views/Settings/MultiAccountDiagnosticsView.swift
@@ -70,7 +70,6 @@ struct MultiAccountDiagnosticsView: View {
         Section("Current account") {
             if let current = appState.currentAccount {
                 labeled("pubkey", value: truncated(current.pubkeyHex))
-                labeled("petname", value: current.petname ?? "—")
                 labeled("profile name", value: current.profile?.displayName ?? "—")
                 labeled("added at", value: dateString(current.addedAt))
                 Button {
@@ -114,7 +113,7 @@ struct MultiAccountDiagnosticsView: View {
                         .foregroundStyle(.green)
                         .font(.caption)
                 }
-                Text(account.petname ?? account.profile?.displayName ?? truncated(account.pubkeyHex))
+                Text(account.profile?.displayName ?? truncated(account.pubkeyHex))
                     .font(.footnote.bold())
                 Spacer()
             }
@@ -174,11 +173,8 @@ struct MultiAccountDiagnosticsView: View {
     }
 
     private func generateTestAccount() {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm:ss"
-        let petname = "Test \(formatter.string(from: Date()))"
         do {
-            _ = try appState.generateAccount(petname: petname)
+            _ = try appState.generateAccount()
             refreshTick += 1
             UINotificationFeedbackGenerator().notificationOccurred(.success)
         } catch {

--- a/ClaveTests/AccountModelTests.swift
+++ b/ClaveTests/AccountModelTests.swift
@@ -12,7 +12,6 @@ final class AccountModelTests: XCTestCase {
     func testAccount_codableRoundtrip_preservesAllFields() throws {
         let original = Account(
             pubkeyHex: "55127fc9e1c03c6b459a3bab72fdb99def1644c5f239bdd09f3e5fb401ed9b21",
-            petname: "POWR Test",
             addedAt: 1714500000.0,
             profile: CachedProfile(
                 displayName: "TestUser",
@@ -23,7 +22,6 @@ final class AccountModelTests: XCTestCase {
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(Account.self, from: data)
         XCTAssertEqual(decoded.pubkeyHex, original.pubkeyHex)
-        XCTAssertEqual(decoded.petname, original.petname)
         XCTAssertEqual(decoded.addedAt, original.addedAt)
         XCTAssertEqual(decoded.profile?.displayName, original.profile?.displayName)
         XCTAssertEqual(decoded.profile?.pictureURL, original.profile?.pictureURL)
@@ -33,28 +31,27 @@ final class AccountModelTests: XCTestCase {
     func testAccount_decodesWithoutOptionalFields() throws {
         // Minimum-shape JSON — only required fields. Used by reinstall
         // recovery (which seeds Account records from listAllPubkeys() with
-        // no petname or profile cache).
+        // no profile cache).
         let json = #"{"pubkeyHex":"abc123","addedAt":1714500000.0}"#
         let data = json.data(using: .utf8)!
         let decoded = try JSONDecoder().decode(Account.self, from: data)
         XCTAssertEqual(decoded.pubkeyHex, "abc123")
         XCTAssertEqual(decoded.addedAt, 1714500000.0)
-        XCTAssertNil(decoded.petname)
         XCTAssertNil(decoded.profile)
     }
 
     func testAccount_idMatchesPubkeyHex() {
         // Identifiable conformance — id is used by SwiftUI ForEach/List
         // identity. Must equal pubkey so picker rows have stable identity
-        // across petname/profile mutations.
-        let acc = Account(pubkeyHex: "abc", petname: nil, addedAt: 0, profile: nil)
+        // across profile mutations.
+        let acc = Account(pubkeyHex: "abc", addedAt: 0, profile: nil)
         XCTAssertEqual(acc.id, "abc")
     }
 
     func testAccount_equatable_isContentBased() {
-        let a1 = Account(pubkeyHex: "abc", petname: "X", addedAt: 1, profile: nil)
-        let a2 = Account(pubkeyHex: "abc", petname: "X", addedAt: 1, profile: nil)
-        let a3 = Account(pubkeyHex: "abc", petname: "Y", addedAt: 1, profile: nil)
+        let a1 = Account(pubkeyHex: "abc", addedAt: 1, profile: nil)
+        let a2 = Account(pubkeyHex: "abc", addedAt: 1, profile: nil)
+        let a3 = Account(pubkeyHex: "abc", addedAt: 2, profile: nil)
         XCTAssertEqual(a1, a2)
         XCTAssertNotEqual(a1, a3)
     }
@@ -199,48 +196,22 @@ final class AccountModelTests: XCTestCase {
         XCTAssertNil(decoded.name)
     }
 
-    // MARK: - Account.displayLabel (build 46 chain: displayName → name → prefix)
-
-    func testAccount_displayLabel_prefersDisplayNameOverPetname() throws {
-        // Build 46: petname is intentionally ignored even when set.
-        // displayName from kind:0 takes precedence.
-        let acc = Account(
-            pubkeyHex: "abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
-            petname: "Legacy Petname",
-            addedAt: 1714500000.0,
-            profile: CachedProfile(displayName: "Display Name", fetchedAt: 1714500000.0)
-        )
-        XCTAssertEqual(acc.displayLabel, "Display Name")
-    }
+    // MARK: - Account.displayLabel (chain: displayName → name → prefix)
 
     func testAccount_displayLabel_fallsBackToNameWhenNoDisplayName() throws {
         // displayName missing → falls back to kind:0 short name (handle).
         let acc = Account(
             pubkeyHex: "abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
-            petname: nil,
             addedAt: 1714500000.0,
             profile: CachedProfile(name: "shorthandle", fetchedAt: 1714500000.0)
         )
         XCTAssertEqual(acc.displayLabel, "shorthandle")
     }
 
-    func testAccount_displayLabel_ignoresPetname_usesPubkeyPrefixWhenNoProfile() throws {
-        // No profile cached at all — falls through to npub prefix.
-        // Petname is set but should be ignored.
-        let acc = Account(
-            pubkeyHex: "abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
-            petname: "ShouldBeIgnored",
-            addedAt: 1714500000.0,
-            profile: nil
-        )
-        XCTAssertEqual(acc.displayLabel, "abc123de")
-    }
-
     func testAccount_displayLabel_prefersDisplayNameOverName() throws {
         // When both displayName and name are set, displayName wins.
         let acc = Account(
             pubkeyHex: "abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
-            petname: nil,
             addedAt: 1714500000.0,
             profile: CachedProfile(
                 displayName: "Alice Smith",
@@ -256,7 +227,6 @@ final class AccountModelTests: XCTestCase {
         // to 8-char pubkey prefix.
         let acc = Account(
             pubkeyHex: "abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
-            petname: nil,
             addedAt: 1714500000.0,
             profile: CachedProfile(fetchedAt: 1714500000.0)
         )

--- a/ClaveTests/AppStateMultiAccountTests.swift
+++ b/ClaveTests/AppStateMultiAccountTests.swift
@@ -6,13 +6,11 @@ import XCTest
 /// Verifies:
 /// - `accounts` + `currentAccount` published state
 /// - Derived `signerPubkeyHex` and `profile` from currentAccount
-/// - `switchToAccount`, `addAccount`, `generateAccount`, `deleteAccount`,
-///   `renamePetname`
+/// - `switchToAccount`, `addAccount`, `generateAccount`, `deleteAccount`
 /// - `recoverAccountsFromKeychainIfNeeded` (reinstall recovery from
 ///   iOS Storage settings UserDefaults wipe)
 /// - `cleanupOrphanLegacyKeychainEntry` (defensive every-launch sweep
 ///   for build-31-era bootstrap orphans; sunset candidate)
-/// - Petname sanitization (audit 2026-04-30 finding A3)
 /// - `deleteAccount` ordering (audit finding A2)
 ///
 /// These tests focus on local state transitions (UserDefaults +
@@ -87,22 +85,21 @@ final class AppStateMultiAccountTests: XCTestCase {
         XCTAssertEqual(appState.signerPubkeyHex, "")
         XCTAssertFalse(appState.isKeyImported)
 
-        _ = try appState.addAccount(nsec: testNsecA, petname: nil)
+        _ = try appState.addAccount(nsec: testNsecA)
         XCTAssertEqual(appState.signerPubkeyHex, testPubkeyA)
         XCTAssertTrue(appState.isKeyImported)
     }
 
     func testProfile_derivedFromCurrentAccount() throws {
-        _ = try appState.addAccount(nsec: testNsecA, petname: nil)
+        _ = try appState.addAccount(nsec: testNsecA)
         XCTAssertNil(appState.profile)  // No fetch yet
     }
 
     // MARK: - addAccount
 
     func testAddAccount_appendsToList_andSetsAsCurrent() throws {
-        let result = try appState.addAccount(nsec: testNsecA, petname: "Work")
+        let result = try appState.addAccount(nsec: testNsecA)
         XCTAssertEqual(result.pubkeyHex, testPubkeyA)
-        XCTAssertEqual(result.petname, "Work")
         XCTAssertEqual(appState.accounts.count, 1)
         XCTAssertEqual(appState.currentAccount?.pubkeyHex, testPubkeyA)
         // Keychain entry written
@@ -110,15 +107,15 @@ final class AppStateMultiAccountTests: XCTestCase {
     }
 
     func testAddAccount_duplicateNsec_switchesToExisting() throws {
-        _ = try appState.addAccount(nsec: testNsecA, petname: "First")
-        _ = try appState.addAccount(nsec: testNsecB, petname: "Second")
+        let firstAddedAt = try appState.addAccount(nsec: testNsecA).addedAt
+        _ = try appState.addAccount(nsec: testNsecB)
         // currentAccount is now testPubkeyB
         XCTAssertEqual(appState.currentAccount?.pubkeyHex, testPubkeyB)
 
         // Re-add the first nsec — should switch back, not duplicate
-        let result = try appState.addAccount(nsec: testNsecA, petname: "Should be ignored")
+        let result = try appState.addAccount(nsec: testNsecA)
         XCTAssertEqual(result.pubkeyHex, testPubkeyA)
-        XCTAssertEqual(result.petname, "First", "Existing petname must not be overwritten by re-add")
+        XCTAssertEqual(result.addedAt, firstAddedAt, "Re-add must return the existing row, not a fresh one")
         XCTAssertEqual(appState.accounts.count, 2, "Re-add must not duplicate the row")
         XCTAssertEqual(appState.currentAccount?.pubkeyHex, testPubkeyA, "Re-add must switch to existing")
     }
@@ -199,34 +196,6 @@ final class AppStateMultiAccountTests: XCTestCase {
         XCTAssertEqual(appState.accounts.count, 0)
     }
 
-    // MARK: - renamePetname (audit A3 sanitization)
-
-    func testRenamePetname_persistsAndUpdatesCurrent() throws {
-        _ = try appState.addAccount(nsec: testNsecA, petname: "Old")
-        appState.renamePetname(for: testPubkeyA, to: "New")
-        XCTAssertEqual(appState.currentAccount?.petname, "New")
-        XCTAssertEqual(appState.accounts.first?.petname, "New")
-    }
-
-    func testRenamePetname_sanitizesInput_audit_A3() throws {
-        _ = try appState.addAccount(nsec: testNsecA)
-        // Whitespace + newlines + super long
-        let dirty = "  \n  Hello\nWorld\(String(repeating: "X", count: 200))\n  "
-        appState.renamePetname(for: testPubkeyA, to: dirty)
-        let result = appState.currentAccount?.petname
-        XCTAssertNotNil(result)
-        XCTAssertFalse(result!.contains("\n"), "Newlines must be stripped")
-        XCTAssertFalse(result!.hasPrefix(" "), "Leading whitespace must be trimmed")
-        XCTAssertFalse(result!.hasSuffix(" "), "Trailing whitespace must be trimmed")
-        XCTAssertLessThanOrEqual(result!.count, 64, "Length must be capped at 64 chars")
-    }
-
-    func testRenamePetname_emptyAfterSanitization_setsNilNotEmptyString() throws {
-        _ = try appState.addAccount(nsec: testNsecA, petname: "Initial")
-        appState.renamePetname(for: testPubkeyA, to: "   \n\n   ")
-        XCTAssertNil(appState.currentAccount?.petname,
-                     "All-whitespace input should clear the petname, not leave empty string")
-    }
 
     // MARK: - Reinstall recovery from Keychain
 
@@ -254,7 +223,7 @@ final class AppStateMultiAccountTests: XCTestCase {
 
     func testReinstallRecovery_doesNotRunWhenAccountsKeyAlreadyPopulated() throws {
         // Setup: normal state with accountsKey already set (no recovery needed)
-        _ = try appState.addAccount(nsec: testNsecA, petname: "Existing")
+        _ = try appState.addAccount(nsec: testNsecA)
 
         // Now plant a Keychain entry that's NOT in accountsKey — recovery
         // would pick it up if it ran. Verify recovery doesn't run.
@@ -265,7 +234,7 @@ final class AppStateMultiAccountTests: XCTestCase {
 
         // Only the original account is in the list — recovery did NOT run
         XCTAssertEqual(fresh.accounts.count, 1, "Recovery must skip when accountsKey is already populated")
-        XCTAssertEqual(fresh.accounts.first?.petname, "Existing")
+        XCTAssertEqual(fresh.accounts.first?.pubkeyHex, testPubkeyA, "Original account preserved; recovery did not add testPubkeyB")
     }
 
 

--- a/Shared/SharedModels.swift
+++ b/Shared/SharedModels.swift
@@ -284,16 +284,11 @@ struct CachedProfile: Codable, Equatable {
 struct Account: Codable, Identifiable, Equatable {
     var id: String { pubkeyHex }
 
-    /// Hex-encoded 32-byte secp256k1 public key. Stable across petname
-    /// renames + profile refreshes; used as the kSecAttrAccount for the
-    /// account's Keychain entry, and as the foreign key on every
-    /// per-account SharedStorage record.
+    /// Hex-encoded 32-byte secp256k1 public key. Stable across profile
+    /// refreshes; used as the kSecAttrAccount for the account's Keychain
+    /// entry, and as the foreign key on every per-account SharedStorage
+    /// record.
     let pubkeyHex: String
-
-    /// User-supplied label, optional. Preferred display name when set.
-    /// Sanitized at write time (trimmed, newlines stripped, capped at 64
-    /// chars) — see `AppState.renamePetname` (Task 5).
-    var petname: String?
 
     /// `Date.timeIntervalSince1970` of when this account was added on
     /// this device. Used for "Added on …" rows in account detail views.
@@ -307,12 +302,10 @@ struct Account: Codable, Identifiable, Equatable {
 
     init(
         pubkeyHex: String,
-        petname: String? = nil,
         addedAt: Double,
         profile: CachedProfile? = nil
     ) {
         self.pubkeyHex = pubkeyHex
-        self.petname = petname
         self.addedAt = addedAt
         self.profile = profile
     }
@@ -320,10 +313,6 @@ struct Account: Codable, Identifiable, Equatable {
 
 extension Account {
     /// Resolution order: kind:0 displayName → kind:0 name → 8-char npub prefix.
-    /// Petname (legacy editable nickname) is intentionally NOT consulted —
-    /// kind:0 is now the source of truth for account identity. The
-    /// `petname` field on Account remains for on-disk backward compat
-    /// but UI ignores it as of build 46.
     var displayLabel: String {
         if let d = profile?.displayName, !d.isEmpty { return d }
         if let n = profile?.name, !n.isEmpty { return n }


### PR DESCRIPTION
## Summary

Petname was deprecated in build 46 — `Account.displayLabel` was updated to ignore it, with a comment noting *"petname field on Account remains for on-disk backward compat but UI ignores it as of build 46."* Two builds later, petname has **zero production usage**:

- `displayLabel` resolves to kind:0 `displayName` → kind:0 `name` → 8-char pubkey prefix (never consults petname)
- All production callers of `addAccount` / `generateAccount` pass `petname: nil`
- `renamePetname` has zero production callers (only tests exercised it)
- The `@petname` mentions in 3 view doc comments were stale — describing aspirational behavior that never shipped past build 46

The only live use was [MultiAccountDiagnosticsView](https://github.com/DocNR/clave/blob/chore/remove-dead-petname/Clave/Views/Settings/MultiAccountDiagnosticsView.swift) (dev-menu-gated) — its "petname" row + timestamp-petname Generate button. Both removed.

## Numbers

10 files changed, **−108 net LOC** (38 insertions, 146 deletions).

## What was removed

**Production code:**
- `petname: String?` field from `Account` struct + init
- `petname:` parameter from `addAccount` + `generateAccount` + 9 call sites
- `renamePetname(for:to:)` method + doc (~14 LOC)
- `sanitizePetname(_:)` private helper (~7 LOC)
- `Account()` constructor petname args in `AppState+ProfileFetcher.swift`
- petname row + timestamp-petname Generate button in `MultiAccountDiagnosticsView`
- Stale `@petname` doc comments in `SlimIdentityBar`, `SigningAsHeader`, `ConnectAccountContextBar`
- Stale `renamePetname` doc references in 3 source files + 2 test files

**Tests:**
- 3 `renamePetname` tests deleted (the methods they tested are gone)
- 2 `displayLabel`-ignores-petname tests deleted (the assertion is meaningless without petname to ignore)
- 7 incidental tests edited to drop `petname:` argument; `testAddAccount_duplicateNsec_switchesToExisting` now uses `addedAt` as the disambiguator (was using petname before)
- `testAccount_equatable_isContentBased` now uses `addedAt` as the differentiator

## Backward compatibility

Existing on-disk `Account` JSON has `"petname":null` (or rare non-null values from the dev menu). Swift's `JSONDecoder` ignores unknown keys by default, so build 69+ decoding existing rows is fine — the `petname` key is silently dropped on next encode. **No migration needed.**

## Test plan

- [x] Pre-baseline on `main` (d535054): **236 passed / 0 failed** ✅
- [x] Post-removal on this branch: **231 passed / 0 failed** (236 − 5) ✅
- [x] `** TEST SUCCEEDED **` in both runs
- [x] `grep -rnE "petname|sanitizePetname|renamePetname" --include="*.swift"` → zero matches

## Why now

Lands as a focused dead-code removal PR **before Stage 4a** (AccountManager extraction). Keeps the structural refactor PR clean — Stage 4a can be a pure file move without bundling product decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)