### PR TITLE
refactor: extract PendingApprovalCoordinator (Stage 4b — final stage)

### DIFF
--- a/Clave/AppState+PendingApprovalCoordinator.swift
+++ b/Clave/AppState+PendingApprovalCoordinator.swift
@@ -1,0 +1,276 @@
+import Foundation
+
+/// Pending-approval alert chain coordinator — extracted from AppState per the
+/// AppState god-object refactor (Stage 4b). Owns the approve/deny lifecycle,
+/// the alert-chain state machine (build 55–60 polish sprint), and the
+/// lock-screen action static handler.
+///
+/// Lives in an extension because the methods read/write `@Observable` stored
+/// state on AppState (`pendingRequests`, `dismissedAlertRequestIds`,
+/// `processedInChain`). The `@Observable`-bound computed properties
+/// (`freshPendingRequests`, `activeApprovalRequest`, `pendingApprovalQueueDepth`,
+/// `chainPosition`, `chainTotal`) and stored properties remain in the main
+/// AppState class declaration to preserve `@Observable` macro behavior intact
+/// — same defensive pattern as Stage 3b's `var profile`.
+extension AppState {
+
+    /// Mark the currently-active approval request as alert-dismissed. The
+    /// request stays in `pendingRequests` so the bell badge still reflects
+    /// it; only the alert presentation is suppressed. Idempotent — no-op
+    /// if no active request.
+    ///
+    /// Internal helper retained for testing and potential future per-request
+    /// dismiss UI; the root alert's "Not now" button calls
+    /// `dismissAllActiveAlerts` instead so a single tap escapes the whole
+    /// batch (see method below for rationale).
+    func dismissActiveAlert() {
+        guard let id = activeApprovalRequest?.id else { return }
+        dismissedAlertRequestIds.insert(id)
+    }
+
+    /// Mark every currently-fresh pending request as alert-dismissed in one
+    /// pass. Called from the root alert's "Not now" button.
+    ///
+    /// Why dismiss all rather than just the active one: per-request
+    /// dismissal would auto-chain to the next request's alert immediately
+    /// — which is exactly the "alert keeps popping back up" UX the user
+    /// originally complained about. "Not now" is a session-level defer
+    /// ("handle the whole batch via the bell"), distinct from Approve /
+    /// Deny which are per-request decisions.
+    ///
+    /// New requests arriving after this call still arm the alert because
+    /// their ids aren't in the dismissed set.
+    func dismissAllActiveAlerts() {
+        for request in freshPendingRequests {
+            dismissedAlertRequestIds.insert(request.id)
+        }
+        // Chain is closed by user — reset progress so the next chain
+        // (when a new request arrives) starts at "1 of N" again.
+        processedInChain = 0
+    }
+
+    func refreshPendingRequests() {
+        // Read-only refresh: pull current on-disk state into the
+        // @Observable property. Stale-entry purging is intentionally
+        // NOT run here — `refreshPendingRequests` is also triggered by
+        // the in-process `.pendingRequestsUpdated` observer, which fires
+        // on every queue mutation including legacy/migration writes that
+        // may use sentinel timestamps. The freshness filter at read time
+        // (`freshPendingRequests` computed) keeps the UI clean; the hard
+        // purge below runs from explicit user-active triggers
+        // (MainTabView scenePhase `.active`) where stale-row eviction is
+        // safe and desirable.
+        pendingRequests = SharedStorage.getPendingRequests()
+        // Defensive chain-counter reset: any path that empties the alert
+        // chain (TTL purge clearing the active request, lock-screen
+        // approve/deny while app is alive, multi-account switch, etc.)
+        // funnels through `pendingRequests` mutation → this observer.
+        // If no chain is active, processedInChain MUST be 0 so the next
+        // chain (when a fresh request arrives) starts at "1 of N" again.
+        if activeApprovalRequest == nil && processedInChain > 0 {
+            processedInChain = 0
+        }
+    }
+
+    /// Removes pending requests aged past `pendingRequestTTLSeconds` from
+    /// `SharedStorage` and writes an `ActivityEntry` with status `"expired"`
+    /// for each. Called from `refreshPendingRequests` (which runs on
+    /// `.pendingRequestsUpdated`, scenePhase `.active`, and approve/deny).
+    /// Idempotent: no-op when nothing is stale.
+    ///
+    /// Why a hard purge instead of a read-time filter only: the alert
+    /// binding, bell badge, and inbox sheet all derive from
+    /// `pendingRequests`. If we only filtered at read time, stale rows
+    /// would persist on disk (visible to the next NSE wake, would cap
+    /// the queue at 20, and lock-screen action handlers might still
+    /// resolve them by id). Purging keeps storage and the UI in sync.
+    func purgeStalePendingRequests() {
+        let cutoff = Date().timeIntervalSince1970 - Self.pendingRequestTTLSeconds
+        let onDisk = SharedStorage.getPendingRequests()
+        let stale = onDisk.filter { $0.timestamp <= cutoff }
+        guard !stale.isEmpty else { return }
+        for request in stale {
+            SharedStorage.removePendingRequest(id: request.id)
+            PendingApprovalBanner.clear(requestId: request.id)
+            let entry = ActivityEntry(
+                id: UUID().uuidString,
+                method: request.method,
+                eventKind: request.eventKind,
+                clientPubkey: request.clientPubkey,
+                timestamp: Date().timeIntervalSince1970,
+                status: "expired",
+                errorMessage: "Request timed out before user response",
+                signerPubkeyHex: request.signerPubkeyHex
+            )
+            SharedStorage.logActivity(entry)
+        }
+    }
+
+    /// Set or clear a per-kind override on the (signer, client)
+    /// permissions row. Called from `PendingRequestDetailView` when the
+    /// user toggles "Always allow this kind from <client>". No-op if the
+    /// permissions row doesn't exist (the client must already be paired).
+    func setKindOverride(signer: String, client: String, kind: Int, allowed: Bool) {
+        guard var perms = SharedStorage.getClientPermissions(signer: signer, client: client) else {
+            return
+        }
+        perms.kindOverrides[kind] = allowed
+        SharedStorage.saveClientPermissions(perms)
+    }
+
+    /// Outcome of an approve-pending-request attempt. Used by
+    /// PendingApprovalsView to decide between success haptic, error alert, or
+    /// keeping the pending row available for retry.
+    enum ApproveOutcome: Equatable {
+        case signed
+        case failedKeepingPending(reason: String)
+        case failedAndRemoved(reason: String)
+    }
+
+    /// Approve a pending request from inside the running app (inbox swipe,
+    /// detail-view button, root alert). Thin delegate to the static
+    /// `performApprove` helper plus chain-position advancement.
+    ///
+    /// On `.signed` or `.failedAndRemoved` outcomes the request is gone
+    /// from `pendingRequests`, so the chain progresses one step. We pull
+    /// fresh state synchronously (don't wait for the
+    /// `.pendingRequestsUpdated` observer's main-queue dispatch) and bump
+    /// `processedInChain` in the same actor block so the alert title
+    /// re-evaluates atomically — without the sync, SwiftUI would briefly
+    /// paint "X of total-1" before settling on "X of total".
+    ///
+    /// `.failedKeepingPending` keeps the request for retry, so the chain
+    /// doesn't advance.
+    func approvePendingRequest(_ request: PendingRequest) async -> ApproveOutcome {
+        let outcome = await Self.performApprove(request)
+        switch outcome {
+        case .signed, .failedAndRemoved:
+            advanceChainPosition()
+        case .failedKeepingPending:
+            break
+        }
+        return outcome
+    }
+
+    /// Deny a pending request from inside the running app. Like approve,
+    /// advances the chain counter synchronously so the alert title
+    /// re-evaluates atomically with the queue shrinkage.
+    func denyPendingRequest(_ request: PendingRequest) {
+        Self.performDeny(request)
+        advanceChainPosition()
+    }
+
+    /// Synchronously refresh `pendingRequests` from `SharedStorage`,
+    /// increment `processedInChain`, and reset on natural chain end.
+    /// Called from approve/deny instance methods. Pulls state from
+    /// `SharedStorage` directly because the `.pendingRequestsUpdated`
+    /// observer's main-queue dispatch hasn't run yet at this point —
+    /// without the explicit pull, `pendingRequests` would still hold
+    /// the just-removed request when the title re-evaluates.
+    private func advanceChainPosition() {
+        pendingRequests = SharedStorage.getPendingRequests()
+        processedInChain += 1
+        // Natural chain end (queue drained or all remaining are dismissed)
+        // resets the counter so the next chain starts fresh.
+        if activeApprovalRequest == nil {
+            processedInChain = 0
+        }
+    }
+
+    /// Static entry point for the lock-screen Approve / Deny notification
+    /// action handler. Safe to call from `AppDelegate` even during a cold
+    /// launch where `AppState` (held by `ContentView`'s @State) may not
+    /// have initialized yet — the work is done via `SharedStorage` +
+    /// `LightSigner` directly. UI refresh on the running-app side is
+    /// driven by `SharedStorage.removePendingRequest` posting
+    /// `.pendingRequestsUpdated`, which `AppState`'s existing observer
+    /// catches when alive.
+    ///
+    /// Looking up the request from storage by id (rather than passing a
+    /// `PendingRequest` through `userInfo`) keeps the wire format simple:
+    /// the notification only carries the id, the storage row carries the
+    /// full record. Idempotent: if the request was already handled (in-app
+    /// alert finished it, second action tap, expired purge), the lookup
+    /// returns nil and we just clear any lingering banner.
+    static func handlePendingApprovalAction(requestId: String, actionId: String) async {
+        guard let request = SharedStorage.getPendingRequests().first(where: { $0.id == requestId }) else {
+            PendingApprovalBanner.clear(requestId: requestId)
+            return
+        }
+        switch actionId {
+        case PendingApprovalCategory.approveActionId:
+            _ = await performApprove(request)
+        case PendingApprovalCategory.denyActionId:
+            performDeny(request)
+        default:
+            break
+        }
+    }
+
+    /// Approve a pending request: sign and publish the response.
+    /// Task 5: loads by the request's signer pubkey (PendingRequest.signerPubkeyHex,
+    /// added in Task 3); falls back to the current account for legacy rows
+    /// (UserDefaults read so this works without an AppState instance).
+    ///
+    /// Failure handling: relay rejection of the response wrapper (transient
+    /// drop, rate-limit, auth) keeps the pending row so the user can retry
+    /// from the inbox. Hard failures (no nsec, malformed event JSON, decoder
+    /// error) clear the row because retry can't succeed.
+    static func performApprove(_ request: PendingRequest) async -> ApproveOutcome {
+        let signer: String
+        if !request.signerPubkeyHex.isEmpty {
+            signer = request.signerPubkeyHex
+        } else {
+            signer = SharedConstants.sharedDefaults.string(
+                forKey: SharedConstants.currentSignerPubkeyHexKey
+            ) ?? ""
+        }
+        guard !signer.isEmpty,
+              let nsec = SharedKeychain.loadNsec(for: signer) else {
+            performRemovePending(request)
+            return .failedAndRemoved(reason: "Signing key unavailable.")
+        }
+
+        let privateKey: Data
+        do {
+            privateKey = try Bech32.decodeNsec(nsec)
+        } catch {
+            performRemovePending(request)
+            return .failedAndRemoved(reason: "Could not decode signing key.")
+        }
+
+        guard let data = request.requestEventJSON.data(using: .utf8),
+              let requestEvent = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            performRemovePending(request)
+            return .failedAndRemoved(reason: "Pending request data corrupted.")
+        }
+
+        do {
+            let result = try await LightSigner.handleRequest(
+                privateKey: privateKey,
+                requestEvent: requestEvent,
+                skipProtection: true,
+                skipDedupe: true,
+                responseRelayUrl: request.responseRelayUrl
+            )
+            if result.status == "signed" {
+                performRemovePending(request)
+                return .signed
+            }
+            let reason = result.errorMessage ?? "Relay did not accept the signed response. Try Approve again."
+            return .failedKeepingPending(reason: reason)
+        } catch {
+            performRemovePending(request)
+            return .failedAndRemoved(reason: error.localizedDescription)
+        }
+    }
+
+    static func performDeny(_ request: PendingRequest) {
+        performRemovePending(request)
+    }
+
+    private static func performRemovePending(_ request: PendingRequest) {
+        SharedStorage.removePendingRequest(id: request.id)
+        PendingApprovalBanner.clear(requestId: request.id)
+    }
+}

--- a/Clave/AppState.swift
+++ b/Clave/AppState.swift
@@ -103,7 +103,7 @@ final class AppState {
     /// set. Dismissed-then-approved/denied/expired ids stay in the set but
     /// are harmless — the underlying request is gone from `pendingRequests`
     /// so the filter has nothing to skip past.
-    private var dismissedAlertRequestIds: Set<String> = []
+    var dismissedAlertRequestIds: Set<String> = []
 
     /// First fresh pending request whose alert has not been dismissed —
     /// drives `MainTabView`'s root alert. Auto-chains: when the user
@@ -122,40 +122,6 @@ final class AppState {
         freshPendingRequests.count
     }
 
-    /// Mark the currently-active approval request as alert-dismissed. The
-    /// request stays in `pendingRequests` so the bell badge still reflects
-    /// it; only the alert presentation is suppressed. Idempotent — no-op
-    /// if no active request.
-    ///
-    /// Internal helper retained for testing and potential future per-request
-    /// dismiss UI; the root alert's "Not now" button calls
-    /// `dismissAllActiveAlerts` instead so a single tap escapes the whole
-    /// batch (see method below for rationale).
-    func dismissActiveAlert() {
-        guard let id = activeApprovalRequest?.id else { return }
-        dismissedAlertRequestIds.insert(id)
-    }
-
-    /// Mark every currently-fresh pending request as alert-dismissed in one
-    /// pass. Called from the root alert's "Not now" button.
-    ///
-    /// Why dismiss all rather than just the active one: per-request
-    /// dismissal would auto-chain to the next request's alert immediately
-    /// — which is exactly the "alert keeps popping back up" UX the user
-    /// originally complained about. "Not now" is a session-level defer
-    /// ("handle the whole batch via the bell"), distinct from Approve /
-    /// Deny which are per-request decisions.
-    ///
-    /// New requests arriving after this call still arm the alert because
-    /// their ids aren't in the dismissed set.
-    func dismissAllActiveAlerts() {
-        for request in freshPendingRequests {
-            dismissedAlertRequestIds.insert(request.id)
-        }
-        // Chain is closed by user — reset progress so the next chain
-        // (when a new request arrives) starts at "1 of N" again.
-        processedInChain = 0
-    }
 
     // MARK: - Alert chain position tracking
     //
@@ -178,7 +144,7 @@ final class AppState {
     /// reset is defensive — multiple paths can end a chain (TTL purge,
     /// lock-screen action while app alive, dismissAll), and we don't
     /// want stale progress carrying into the next chain.
-    private(set) var processedInChain: Int = 0
+    var processedInChain: Int = 0
 
     /// 1-based position of the active request within the current chain.
     /// Used in the root alert's title. Always >= 1 when
@@ -376,235 +342,6 @@ final class AppState {
         if isKeyImported && !deviceToken.isEmpty {
             registerAllAccountsWithProxy()
         }
-    }
-
-
-
-
-    func refreshPendingRequests() {
-        // Read-only refresh: pull current on-disk state into the
-        // @Observable property. Stale-entry purging is intentionally
-        // NOT run here — `refreshPendingRequests` is also triggered by
-        // the in-process `.pendingRequestsUpdated` observer, which fires
-        // on every queue mutation including legacy/migration writes that
-        // may use sentinel timestamps. The freshness filter at read time
-        // (`freshPendingRequests` computed) keeps the UI clean; the hard
-        // purge below runs from explicit user-active triggers
-        // (MainTabView scenePhase `.active`) where stale-row eviction is
-        // safe and desirable.
-        pendingRequests = SharedStorage.getPendingRequests()
-        // Defensive chain-counter reset: any path that empties the alert
-        // chain (TTL purge clearing the active request, lock-screen
-        // approve/deny while app is alive, multi-account switch, etc.)
-        // funnels through `pendingRequests` mutation → this observer.
-        // If no chain is active, processedInChain MUST be 0 so the next
-        // chain (when a fresh request arrives) starts at "1 of N" again.
-        if activeApprovalRequest == nil && processedInChain > 0 {
-            processedInChain = 0
-        }
-    }
-
-    /// Removes pending requests aged past `pendingRequestTTLSeconds` from
-    /// `SharedStorage` and writes an `ActivityEntry` with status `"expired"`
-    /// for each. Called from `refreshPendingRequests` (which runs on
-    /// `.pendingRequestsUpdated`, scenePhase `.active`, and approve/deny).
-    /// Idempotent: no-op when nothing is stale.
-    ///
-    /// Why a hard purge instead of a read-time filter only: the alert
-    /// binding, bell badge, and inbox sheet all derive from
-    /// `pendingRequests`. If we only filtered at read time, stale rows
-    /// would persist on disk (visible to the next NSE wake, would cap
-    /// the queue at 20, and lock-screen action handlers might still
-    /// resolve them by id). Purging keeps storage and the UI in sync.
-    func purgeStalePendingRequests() {
-        let cutoff = Date().timeIntervalSince1970 - Self.pendingRequestTTLSeconds
-        let onDisk = SharedStorage.getPendingRequests()
-        let stale = onDisk.filter { $0.timestamp <= cutoff }
-        guard !stale.isEmpty else { return }
-        for request in stale {
-            SharedStorage.removePendingRequest(id: request.id)
-            PendingApprovalBanner.clear(requestId: request.id)
-            let entry = ActivityEntry(
-                id: UUID().uuidString,
-                method: request.method,
-                eventKind: request.eventKind,
-                clientPubkey: request.clientPubkey,
-                timestamp: Date().timeIntervalSince1970,
-                status: "expired",
-                errorMessage: "Request timed out before user response",
-                signerPubkeyHex: request.signerPubkeyHex
-            )
-            SharedStorage.logActivity(entry)
-        }
-    }
-
-    /// Set or clear a per-kind override on the (signer, client)
-    /// permissions row. Called from `PendingRequestDetailView` when the
-    /// user toggles "Always allow this kind from <client>". No-op if the
-    /// permissions row doesn't exist (the client must already be paired).
-    func setKindOverride(signer: String, client: String, kind: Int, allowed: Bool) {
-        guard var perms = SharedStorage.getClientPermissions(signer: signer, client: client) else {
-            return
-        }
-        perms.kindOverrides[kind] = allowed
-        SharedStorage.saveClientPermissions(perms)
-    }
-
-
-    /// Outcome of an approve-pending-request attempt. Used by
-    /// PendingApprovalsView to decide between success haptic, error alert, or
-    /// keeping the pending row available for retry.
-    enum ApproveOutcome: Equatable {
-        case signed
-        case failedKeepingPending(reason: String)
-        case failedAndRemoved(reason: String)
-    }
-
-    /// Approve a pending request from inside the running app (inbox swipe,
-    /// detail-view button, root alert). Thin delegate to the static
-    /// `performApprove` helper plus chain-position advancement.
-    ///
-    /// On `.signed` or `.failedAndRemoved` outcomes the request is gone
-    /// from `pendingRequests`, so the chain progresses one step. We pull
-    /// fresh state synchronously (don't wait for the
-    /// `.pendingRequestsUpdated` observer's main-queue dispatch) and bump
-    /// `processedInChain` in the same actor block so the alert title
-    /// re-evaluates atomically — without the sync, SwiftUI would briefly
-    /// paint "X of total-1" before settling on "X of total".
-    ///
-    /// `.failedKeepingPending` keeps the request for retry, so the chain
-    /// doesn't advance.
-    func approvePendingRequest(_ request: PendingRequest) async -> ApproveOutcome {
-        let outcome = await Self.performApprove(request)
-        switch outcome {
-        case .signed, .failedAndRemoved:
-            advanceChainPosition()
-        case .failedKeepingPending:
-            break
-        }
-        return outcome
-    }
-
-    /// Deny a pending request from inside the running app. Like approve,
-    /// advances the chain counter synchronously so the alert title
-    /// re-evaluates atomically with the queue shrinkage.
-    func denyPendingRequest(_ request: PendingRequest) {
-        Self.performDeny(request)
-        advanceChainPosition()
-    }
-
-    /// Synchronously refresh `pendingRequests` from `SharedStorage`,
-    /// increment `processedInChain`, and reset on natural chain end.
-    /// Called from approve/deny instance methods. Pulls state from
-    /// `SharedStorage` directly because the `.pendingRequestsUpdated`
-    /// observer's main-queue dispatch hasn't run yet at this point —
-    /// without the explicit pull, `pendingRequests` would still hold
-    /// the just-removed request when the title re-evaluates.
-    private func advanceChainPosition() {
-        pendingRequests = SharedStorage.getPendingRequests()
-        processedInChain += 1
-        // Natural chain end (queue drained or all remaining are dismissed)
-        // resets the counter so the next chain starts fresh.
-        if activeApprovalRequest == nil {
-            processedInChain = 0
-        }
-    }
-
-    /// Static entry point for the lock-screen Approve / Deny notification
-    /// action handler. Safe to call from `AppDelegate` even during a cold
-    /// launch where `AppState` (held by `ContentView`'s @State) may not
-    /// have initialized yet — the work is done via `SharedStorage` +
-    /// `LightSigner` directly. UI refresh on the running-app side is
-    /// driven by `SharedStorage.removePendingRequest` posting
-    /// `.pendingRequestsUpdated`, which `AppState`'s existing observer
-    /// catches when alive.
-    ///
-    /// Looking up the request from storage by id (rather than passing a
-    /// `PendingRequest` through `userInfo`) keeps the wire format simple:
-    /// the notification only carries the id, the storage row carries the
-    /// full record. Idempotent: if the request was already handled (in-app
-    /// alert finished it, second action tap, expired purge), the lookup
-    /// returns nil and we just clear any lingering banner.
-    static func handlePendingApprovalAction(requestId: String, actionId: String) async {
-        guard let request = SharedStorage.getPendingRequests().first(where: { $0.id == requestId }) else {
-            PendingApprovalBanner.clear(requestId: requestId)
-            return
-        }
-        switch actionId {
-        case PendingApprovalCategory.approveActionId:
-            _ = await performApprove(request)
-        case PendingApprovalCategory.denyActionId:
-            performDeny(request)
-        default:
-            break
-        }
-    }
-
-    /// Approve a pending request: sign and publish the response.
-    /// Task 5: loads by the request's signer pubkey (PendingRequest.signerPubkeyHex,
-    /// added in Task 3); falls back to the current account for legacy rows
-    /// (UserDefaults read so this works without an AppState instance).
-    ///
-    /// Failure handling: relay rejection of the response wrapper (transient
-    /// drop, rate-limit, auth) keeps the pending row so the user can retry
-    /// from the inbox. Hard failures (no nsec, malformed event JSON, decoder
-    /// error) clear the row because retry can't succeed.
-    static func performApprove(_ request: PendingRequest) async -> ApproveOutcome {
-        let signer: String
-        if !request.signerPubkeyHex.isEmpty {
-            signer = request.signerPubkeyHex
-        } else {
-            signer = SharedConstants.sharedDefaults.string(
-                forKey: SharedConstants.currentSignerPubkeyHexKey
-            ) ?? ""
-        }
-        guard !signer.isEmpty,
-              let nsec = SharedKeychain.loadNsec(for: signer) else {
-            performRemovePending(request)
-            return .failedAndRemoved(reason: "Signing key unavailable.")
-        }
-
-        let privateKey: Data
-        do {
-            privateKey = try Bech32.decodeNsec(nsec)
-        } catch {
-            performRemovePending(request)
-            return .failedAndRemoved(reason: "Could not decode signing key.")
-        }
-
-        guard let data = request.requestEventJSON.data(using: .utf8),
-              let requestEvent = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            performRemovePending(request)
-            return .failedAndRemoved(reason: "Pending request data corrupted.")
-        }
-
-        do {
-            let result = try await LightSigner.handleRequest(
-                privateKey: privateKey,
-                requestEvent: requestEvent,
-                skipProtection: true,
-                skipDedupe: true,
-                responseRelayUrl: request.responseRelayUrl
-            )
-            if result.status == "signed" {
-                performRemovePending(request)
-                return .signed
-            }
-            let reason = result.errorMessage ?? "Relay did not accept the signed response. Try Approve again."
-            return .failedKeepingPending(reason: reason)
-        } catch {
-            performRemovePending(request)
-            return .failedAndRemoved(reason: error.localizedDescription)
-        }
-    }
-
-    static func performDeny(_ request: PendingRequest) {
-        performRemovePending(request)
-    }
-
-    private static func performRemovePending(_ request: PendingRequest) {
-        SharedStorage.removePendingRequest(id: request.id)
-        PendingApprovalBanner.clear(requestId: request.id)
     }
 
 


### PR DESCRIPTION
## Summary

🏁 **Final stage of the AppState god-object refactor sprint.** Extracts the approve/deny lifecycle, the alert-chain state machine (build 55–60 polish sprint), and the lock-screen action static handler. After this lands, AppState.swift hits the BACKLOG-sketched slim target.

## Numbers

| File | Before | After | Δ |
|---|---|---|---|
| `Clave/AppState.swift` | 611 LOC | **348 LOC** | **−263 (−43.0%)** |
| `Clave/AppState+PendingApprovalCoordinator.swift` | — | 276 LOC | **+276 (new)** |

## 🎯 Sprint total

**AppState.swift: 2,338 → 348 LOC (−85.1%)**

| Stage | LOC removed from AppState |
|---|---|
| Stage 1 (RelayUtils.swift) | −78 |
| Stage 2 (legacy migration deletion) | −524 |
| Stage 3a (AppState+NostrConnect) | −164 |
| Stage 3b (AppState+ProfileFetcher) | −287 |
| Stage 3c (AppState+ProxyClient) | −561 |
| Petname removal | −108 |
| Stage 4a (AppState+AccountManager) | −282 |
| **Stage 4b (AppState+PendingApprovalCoordinator)** | **−263** |
| **Total** | **−1,990 LOC** |

AppState.swift is now a slim `@Observable` container with init, `loadState` coordinator, and the `@Observable` storage + computed property surface.

## What moved (12 methods + nested enum)

- `dismissActiveAlert`, `dismissAllActiveAlerts`
- `refreshPendingRequests`, `purgeStalePendingRequests`
- `setKindOverride`
- `approvePendingRequest`, `denyPendingRequest`, `advanceChainPosition` (`private`)
- `static handlePendingApprovalAction` (lock-screen action handler)
- `static performApprove`, `performDeny`, `performRemovePending` (`private`)
- `enum ApproveOutcome` (nested type)

## What stays in AppState.swift

- **Stored properties** (Swift constraint): `pendingRequests`, `dismissedAlertRequestIds`, `processedInChain`
- **Computed properties** (defensive — Stage 3b precedent for `@Observable`-bound UI-driving computeds): `freshPendingRequests`, `activeApprovalRequest`, `pendingApprovalQueueDepth`, `chainPosition`, `chainTotal`
- **`static let pendingRequestTTLSeconds`** — read by both class-side `freshPendingRequests` and extension-side `purgeStalePendingRequests`. Static members are visible across class+extension boundary so location is just adjacency to consumers.

## Two access widenings (same pattern as bunkerSecretsTick in Stage 4a)

- `private var dismissedAlertRequestIds` → `var` (extension methods need cross-file mutation)
- `private(set) var processedInChain` → `var` (extension `advanceChainPosition`, `dismissAllActiveAlerts`, `refreshPendingRequests` need cross-file mutation)

## Zero behavior change

- Function bodies preserved byte-for-byte
- `private` preserved on `advanceChainPosition`, `performRemovePending` (only called within extension file)
- Static methods relocate; `AppState.handlePendingApprovalAction` resolves identically via type dispatch from `AppDelegate` / NSE
- Cross-extension calls (`approvePendingRequest` → `Self.performApprove`, etc.) all stay within the new extension file

## Test impact: zero

- `AppStatePendingApprovalTests` calls `appState.<method>` via extension dispatch + `AppState.<staticMethod>` via type dispatch — works unchanged
- `LockScreenActionRoutingTests` calls `AppState.handlePendingApprovalAction` via static dispatch — works unchanged

## Test plan

- [x] Pre-baseline (main @ `3b35719`): **231 passed / 0 failed** ✅
- [x] Post-extraction on this branch: **231 passed / 0 failed** ✅
- [x] `** TEST SUCCEEDED **` in both runs (no test count change)
- [ ] After merge: bump pbxproj 70 → 71. Archive build 71 + on-device verify of the alert-chain UI binding (highest behavior-relevance):
  - **Pair a client, sign multiple events back-to-back** so a queue forms — verify chain advances "1 of N → 2 of N → 3 of N"
  - **Lock-screen approve from notification** — verify static handler still works
  - **Lock-screen deny** (same)
  - **Background → foreground → check pending bell badge** updates correctly
  - **"Not now" dismiss-all** — alert chain closes, bell badge stays accurate
  - **Wait 5+ minutes with a pending request** → TTL purge fires + activity log gets `"expired"` entry

## Sprint complete

This PR completes the AppState god-object refactor. AppState.swift is now a slim coordination layer; all functional concerns live in dedicated extension files:

- `Shared/RelayUtils.swift` (Stage 1)
- `Clave/AppState+NostrConnect.swift` (Stage 3a)
- `Clave/AppState+ProfileFetcher.swift` (Stage 3b)
- `Clave/AppState+ProxyClient.swift` (Stage 3c)
- `Clave/AppState+AccountManager.swift` (Stage 4a)
- `Clave/AppState+PendingApprovalCoordinator.swift` (Stage 4b — this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)