### PR TITLE
feat(proxy): /entitlement endpoint + tier-aware /pair-client cap (PR 2/5 — premium tier)

### DIFF
--- a/relay-proxy/proxy.js
+++ b/relay-proxy/proxy.js
@@ -27,6 +27,7 @@ const PONG_TIMEOUT = 10000; // 10 seconds to respond
 const { parseAuthHeader, verifyNip98, sha256Hex } = require("./nip98");
 const { createStorage } = require("./storage");
 const { createClientsStorage } = require("./clients");
+const { createEntitlementsStorage } = require("./entitlements");
 const { createRelayPool } = require("./relayPool");
 const { createApnsClient, shouldPruneToken, parseReason } = require("./apnsClient");
 
@@ -36,6 +37,8 @@ const PUBLIC_PROXY_URL = process.env.PUBLIC_PROXY_URL || "https://proxy.clave.ca
 const storage = createStorage(TOKEN_FILE);
 const CLIENTS_FILE = "./clients.json";
 const clientsStorage = createClientsStorage(CLIENTS_FILE);
+const ENTITLEMENTS_FILE = "./entitlements.json";
+const entitlementsStorage = createEntitlementsStorage(ENTITLEMENTS_FILE);
 let relayPool = null; // initialized in server.listen after all deps are in scope
 const migrationResult = storage.migrateIfLegacy();
 if (migrationResult.migrated) {
@@ -350,9 +353,15 @@ const server = http.createServer((req, res) => {
         const alreadyPaired = clientsStorage.loadAll()
           .some((p) => p.signerPubkey === signerPubkey && p.clientPubkey === client_pubkey);
         const projectedCount = alreadyPaired ? existingCount : existingCount + 1;
-        if (projectedCount > 5) {
+        // Tier-aware cap: free → 5, premium → 30. Default is "free" for any
+        // signer without an entitlement record. Error code stays "pairing_limit"
+        // for backwards compat with iOS handlers; new fields `tier` + dynamic
+        // `limit` carry the additional info iOS PR 5 will read.
+        const tier = entitlementsStorage.tierForPubkey(signerPubkey);
+        const cap = entitlementsStorage.maxClientsForTier(tier);
+        if (projectedCount > cap) {
           res.writeHead(409, { "Content-Type": "application/json" });
-          return res.end(JSON.stringify({ error: "pairing_limit", limit: 5, used: existingCount }));
+          return res.end(JSON.stringify({ error: "pairing_limit", limit: cap, used: existingCount, tier }));
         }
 
         const novel = clientsStorage.novelRelayCount(signerPubkey, relay_urls);
@@ -448,6 +457,94 @@ const server = http.createServer((req, res) => {
         res.end(JSON.stringify({ error: "Internal error" }));
       }
     });
+  } else if (req.method === "GET" && req.url && req.url.startsWith("/entitlement")) {
+    // GET /entitlement?pubkey=<hex>
+    // Auth: NIP-98 (any signer — entitlement state is roughly public; we just
+    //       want the caller to be a real Clave client, not a scraper).
+    // Optional header X-APNs-Token-Prefix (8 hex chars): if present AND the
+    //       queried pubkey has a non-free entitlement, we record this device
+    //       in `devices_seen` for the abuse-tripwire audit. Used by iOS at
+    //       launch + on add-account.
+    //
+    // Wrapped in async IIFE because the outer http.createServer callback is
+    // sync; same pattern other endpoints use via `req.on("end", async () => …)`
+    // for their POST bodies. GET has no body to await, so we await directly.
+    (async () => {
+      try {
+        const authHeader = req.headers["x-clave-auth"];
+        if (!authHeader) {
+          console.log(`[HTTP] /entitlement 401: Missing X-Clave-Auth header`);
+          res.writeHead(401, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "Missing X-Clave-Auth header" }));
+        }
+        let authEvent;
+        try {
+          authEvent = parseAuthHeader(authHeader);
+        } catch (e) {
+          console.log(`[HTTP] /entitlement 401: ${e.message}`);
+          res.writeHead(401, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: e.message }));
+        }
+        // For GET, NIP-98 spec says the URL is the full request URL including
+        // query string; bodyHash is empty (no body).
+        const fullUrl = `${PUBLIC_PROXY_URL}${req.url}`;
+        const result = await verifyNip98(authEvent, fullUrl, "GET", null);
+        if (!result.valid) {
+          console.log(`[HTTP] /entitlement auth failed: ${result.error}`);
+          res.writeHead(401, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: result.error }));
+        }
+
+        let queriedPubkey;
+        try {
+          const u = new URL(req.url, PUBLIC_PROXY_URL);
+          queriedPubkey = u.searchParams.get("pubkey");
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "invalid_url" }));
+        }
+        if (typeof queriedPubkey !== "string" || !/^[0-9a-f]{64}$/.test(queriedPubkey)) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          return res.end(JSON.stringify({ error: "invalid_pubkey" }));
+        }
+
+        const entry = entitlementsStorage.getByPubkey(queriedPubkey);
+        const tier = entitlementsStorage.tierForPubkey(queriedPubkey);
+
+        // Device-tripwire side effect: record this device's APNs token prefix
+        // against the queried pubkey, but only if the entry exists AND is
+        // currently non-free. We don't auto-create entries from queries —
+        // free-tier pubkeys shouldn't accumulate device-tracking data.
+        const tokenPrefix = req.headers["x-apns-token-prefix"];
+        if (entry && tier !== "free" && typeof tokenPrefix === "string" && /^[0-9a-f]{8}$/.test(tokenPrefix)) {
+          entitlementsStorage.recordDevice(queriedPubkey, tokenPrefix);
+        }
+
+        const response = {
+          pubkey: queriedPubkey,
+          tier,
+          max_accounts: entitlementsStorage.maxAccountsForTier(tier),
+          max_clients: entitlementsStorage.maxClientsForTier(tier),
+        };
+        if (entry) {
+          response.granted_at = entry.granted_at;
+          response.expires_at = entry.expires_at;
+          if (entry.granted_by) response.granted_by = entry.granted_by;
+        }
+
+        console.log(
+          `[HTTP] /entitlement pubkey=${queriedPubkey.slice(0, 8)}... tier=${tier}` +
+            (tokenPrefix ? ` device=${tokenPrefix}` : "")
+        );
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        return res.end(JSON.stringify(response));
+      } catch (e) {
+        console.error("[HTTP] /entitlement error:", e.message);
+        res.writeHead(500, { "Content-Type": "application/json" });
+        return res.end(JSON.stringify({ error: "Internal error" }));
+      }
+    })();
   } else if (req.method === "GET" && req.url === "/health") {
     const allTokens = storage.loadTokens();
     const pubkeys = new Set(allTokens.map((t) => t.pubkey));


### PR DESCRIPTION
## Summary

PR 2 of the premium-tier series. Wires the entitlements module from PR #48 into `proxy.js` — the proxy is now the authoritative source for tier resolution and cap enforcement.

**Stacks on [#48](https://github.com/DocNR/clave/pull/48).** Base branch is `feat/entitlements-storage`. Will rebase if PR #48 receives review changes. Merge order: PR #48 → PR 2.

## What this changes

### 1. `entitlementsStorage` initialized at boot
Alongside `clientsStorage` and `tokensStorage`. Reads from `./entitlements.json`. Missing file = everyone is free → no behavior change for current users.

### 2. New endpoint: `GET /entitlement?pubkey=<hex>`

- **Auth**: NIP-98 (any signer — entitlement state is roughly public; auth keeps scrapers out)
- **Response**:
  ```json
  {
    "pubkey": "<hex>",
    "tier": "free" | "premium",
    "max_accounts": 4 | 10,
    "max_clients": 5 | 30,
    "granted_at": 1714000000,    // present if entry exists
    "expires_at": null,           // present if entry exists
    "granted_by": "admin:..."     // present if entry has source
  }
  ```
- **Optional header `X-APNs-Token-Prefix: <8 hex>`**: records the querying device into `devices_seen` for the abuse tripwire, ONLY if the queried pubkey has a non-free entitlement (free tier doesn't accumulate device data — privacy-preserving)

Wrapped in async IIFE because the outer `http.createServer` callback is sync; same pattern other endpoints use via `req.on("end", async () => …)` for POST bodies.

### 3. Tier-aware cap in `/pair-client`

- Replaced hardcoded `if (projectedCount > 5)` with `if (projectedCount > entitlementsStorage.maxClientsForTier(tier))`
- Default tier `"free"` → cap 5 (no behavior change for unprivileged users); tier `"premium"` → cap 30
- Error code stays `pairing_limit` for iOS backwards compat
- Response gains `tier` field; `limit` carries the dynamic cap

## Verification

### Unit tests

- ✅ Full proxy test suite: **111/111 green** (79 existing + 32 from PR #48)
- ✅ `node --check proxy.js` — syntax OK

### Smoke tests on `proxy-test.clave.casa` (refreshed to current main, then this branch deployed)

```
$ curl "https://proxy-test.clave.casa/entitlement?pubkey=aaaa…"
{"error":"Missing X-Clave-Auth header"}    http_status=401   ✅

$ curl -X POST "https://proxy-test.clave.casa/pair-client" -d "{}"
{"error":"Missing X-Clave-Auth header"}    http_status=401   ✅ (no regression)

$ curl "https://proxy-test.clave.casa/health"
{"ok":true,"total_tokens":5,...}            http_status=200   ✅
```

Service logs:
```
[HTTP] Listening on port 3047
[Relay] Connecting to ws://localhost:7778...
[Relay] Connected
[Relay] Watching kind:24133 events for all registered signer pubkeys
[HTTP] /entitlement 401: Missing X-Clave-Auth header   ← endpoint registered, auth firing
[HTTP] /pair-client 401: Missing X-Clave-Auth header
```

### What's NOT verified yet (intentional — PR 4/5 covers these)

- NIP-98 auth path with a real signed event (no shell-friendly NIP-98 signer; needs iOS or `nak` integration)
- Tier-aware cap firing with an actual entitlement record in place — first end-to-end exercise lands when PR 3 (grant CLI) + PR 4/5 (iOS) both ship

The unit-test coverage of the underlying entitlements module (32 tests in PR #48) covers the read paths this endpoint exercises.

## Files changed

`relay-proxy/proxy.js` — 99 insertions, 2 deletions.

## Risk

Low. Production proxy is unaffected (this PR ships to `proxy-test.clave.casa` for verification; deploy to `proxy.clave.casa` only after PR #48 + this PR merge). Even on the test proxy, behavior is unchanged for existing users (no granted entitlements yet → everyone free → cap stays 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)