### PR TITLE
chore(build): block Archive when HEAD isn't pushed

### DIFF
--- a/Clave.xcodeproj/project.pbxproj
+++ b/Clave.xcodeproj/project.pbxproj
@@ -280,6 +280,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EF3D7A302F8BCAE6005A6545 /* Build configuration list for PBXNativeTarget "Clave" */;
 			buildPhases = (
+				EFC0FFEE2F8BCAE3005A6545 /* Preflight: require pushed HEAD before Archive */,
 				EF3D7A0B2F8BCAE3005A6545 /* Sources */,
 				EF3D7A0C2F8BCAE3005A6545 /* Frameworks */,
 				EF3D7A0D2F8BCAE3005A6545 /* Resources */,
@@ -372,6 +373,28 @@
 			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		EFC0FFEE2F8BCAE3005A6545 /* Preflight: require pushed HEAD before Archive */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Preflight: require pushed HEAD before Archive";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/scripts/preflight-archive.sh\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXProject section */
 		EF3D7A072F8BCAE3005A6545 /* Project object */ = {

--- a/scripts/preflight-archive.sh
+++ b/scripts/preflight-archive.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# preflight-archive.sh — refuse to ARCHIVE from commits that aren't on a remote.
+#
+# Why this exists: TestFlight builds were once archived from local-only commits
+# that were never pushed, leaving GitHub `main` ~9 builds behind reality. This
+# guard fails the Archive if the commit being shipped isn't pushed, or if the
+# working tree has uncommitted changes (e.g. a build bump or new icon left behind).
+#
+# It runs ONLY during Xcode Archive (ACTION=install). Normal Debug/Release
+# builds and `xcodebuild build` pass straight through. Read-only git (no fetch),
+# so it is safe under user-script sandboxing.
+set -u
+
+# Only guard the Archive action; let every other build through untouched.
+[ "${ACTION:-build}" = "install" ] || exit 0
+
+REPO="${SRCROOT:-$(pwd)}"
+cd "$REPO" 2>/dev/null || exit 0
+
+fail() {
+  echo "error: ARCHIVE BLOCKED — $1" >&2
+  echo "error: Commit + push your build bump and assets, then archive from a pushed branch (normally main)." >&2
+  echo "error: (If the commit really is pushed, run 'git fetch' so remote-tracking refs are current, then retry.)" >&2
+  exit 1
+}
+
+# Decide whether this checkout is expected to be a git repo.
+# If there is a .git on disk but `git` cannot run (e.g. blocked by the build
+# sandbox), FAIL LOUD rather than silently skipping the guard. Only a genuine
+# non-git checkout (no .git) is allowed to pass through.
+if [ -e "$REPO/.git" ] || git rev-parse --git-dir >/dev/null 2>&1; then
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    fail "expected a git checkout at SRCROOT but 'git' could not run (build sandbox?). Set ENABLE_USER_SCRIPT_SANDBOXING=NO for this target, or push manually before archiving."
+  fi
+else
+  exit 0
+fi
+
+# 1) No uncommitted changes to tracked files.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  fail "working tree has uncommitted changes."
+fi
+
+# 2) HEAD must exist on some remote branch (i.e. it was actually pushed).
+HEAD_SHA=$(git rev-parse HEAD 2>/dev/null)
+if [ -z "$(git branch -r --contains "$HEAD_SHA" 2>/dev/null)" ]; then
+  fail "HEAD ($(git rev-parse --short HEAD 2>/dev/null)) is not on any remote branch — it was never pushed."
+fi
+
+echo "preflight-archive: OK — HEAD $(git rev-parse --short HEAD) is pushed and the tree is clean."
+exit 0


### PR DESCRIPTION
## Why
This session found GitHub \`main\` stale at build 86 while TestFlight had shipped builds 87+ from **unpushed local commits**. Root cause: archives were cut from commits that were never pushed. This adds a guardrail at the actual choke point (Xcode Archive).

## What
- New \`scripts/preflight-archive.sh\` + an Archive-only Run Script build phase on the **Clave** target.
- Fails the Archive when:
  - the working tree has uncommitted changes (e.g. a build bump or new icon left behind), or
  - \`HEAD\` is not on any remote branch (never pushed).
- Runs **only** on \`ACTION=install\` (archive) — Debug/Release builds and \`xcodebuild build\` pass straight through.
- Read-only git (no \`fetch\`); **fails loud** if git can't run under the script sandbox instead of silently skipping.

## Verified
- `plutil -lint` OK; `xcodebuild -list` + `-showBuildSettings` load the target.
- Script tested: clean+pushed → pass; normal build → no-op; uncommitted → block; unpushed HEAD → block; git-unavailable → fail loud; non-git dir → no-op.

## Note
Why not a Claude Code/hookify hook: that only governs CLI tool calls, not a manual Product → Archive in Xcode. The build phase is the only point that can actually block the archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)