### PR TITLE
Verify incoming event signatures (observe-only) + remove in-archive preflight hook

### DIFF
--- a/Clave.xcodeproj/project.pbxproj
+++ b/Clave.xcodeproj/project.pbxproj
@@ -280,7 +280,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EF3D7A302F8BCAE6005A6545 /* Build configuration list for PBXNativeTarget "Clave" */;
 			buildPhases = (
-				EFC0FFEE2F8BCAE3005A6545 /* Preflight: require pushed HEAD before Archive */,
 				EF3D7A0B2F8BCAE3005A6545 /* Sources */,
 				EF3D7A0C2F8BCAE3005A6545 /* Frameworks */,
 				EF3D7A0D2F8BCAE3005A6545 /* Resources */,
@@ -373,28 +372,6 @@
 			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		EFC0FFEE2F8BCAE3005A6545 /* Preflight: require pushed HEAD before Archive */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Preflight: require pushed HEAD before Archive";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/scripts/preflight-archive.sh\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXProject section */
 		EF3D7A072F8BCAE3005A6545 /* Project object */ = {

--- a/ClaveTests/LightEventVerifyTests.swift
+++ b/ClaveTests/LightEventVerifyTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+import CryptoKit
+@testable import Clave
+
+final class LightEventVerifyTests: XCTestCase {
+
+    private let testPrivateKey = Data(hexString: "0000000000000000000000000000000000000000000000000000000000000001")!
+
+    // MARK: - Independent cross-implementation vector
+
+    /// Signed by `nak` (go-nostr, an independent spec-correct implementation),
+    /// sec=0x01, created_at=1700000000. Multi-element tag + `/` in content.
+    /// This proves NIP-01 conformance, not just round-trip self-consistency.
+    func testVerify_acceptsIndependentlySignedEvent() {
+        let event: [String: Any] = [
+            "kind": 24133,
+            "id": "45879c27b4f71dc9613acdaf6b9a63c5d41fdf07502dad5983f1cf20b5fa36b8",
+            "pubkey": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+            "created_at": 1700000000,
+            "tags": [["t", "a", "b", "c"]],
+            "content": "ab/cd",
+            "sig": "85a4a853cfae404cac2d2a3852dc96b515fbce22864fcc7d57a4bc329cd46eb21a0657ecbbeaf7c79cb88045061c71b826aceaea53404cc004f710e322d367e1"
+        ]
+        XCTAssertTrue(LightEvent.verify(event: event),
+                      "must verify an independently-signed (nak/go-nostr) event — proves NIP-01 conformance, not just round-trip consistency")
+    }
+
+    // MARK: - Round-trip
+
+    func testVerify_roundTripSignedEvent() throws {
+        let signed = try LightEvent.sign(
+            privateKey: testPrivateKey,
+            kind: 1,
+            content: "hello world",
+            tags: [["e", "abc"], ["p", "def"]]
+        )
+        XCTAssertTrue(LightEvent.verify(event: signed.toDict()),
+                      "a freshly signed event must verify")
+    }
+
+    func testVerify_roundTripRandomKey() throws {
+        var randBytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, 32, &randBytes)
+        let randomKey = Data(randBytes)
+
+        let signed = try LightEvent.sign(
+            privateKey: randomKey,
+            kind: 30078,
+            content: "arbitrary application data",
+            tags: [["d", "spectr_decks"]]
+        )
+        XCTAssertTrue(LightEvent.verify(event: signed.toDict()),
+                      "a freshly signed event with a random key must verify")
+    }
+
+    // MARK: - Tamper detection (fail-closed)
+
+    func testVerify_rejectsTamperedCreatedAt() throws {
+        let signed = try LightEvent.sign(
+            privateKey: testPrivateKey,
+            kind: 1,
+            content: "tamper test",
+            tags: []
+        )
+        var dict = signed.toDict()
+        dict["created_at"] = signed.createdAt + 1
+        XCTAssertFalse(LightEvent.verify(event: dict),
+                       "tampering created_at must invalidate the id/signature")
+    }
+
+    func testVerify_rejectsTamperedContent() throws {
+        let signed = try LightEvent.sign(
+            privateKey: testPrivateKey,
+            kind: 1,
+            content: "original content",
+            tags: []
+        )
+        var dict = signed.toDict()
+        dict["content"] = "evil content"
+        XCTAssertFalse(LightEvent.verify(event: dict),
+                       "tampering content must invalidate the id/signature")
+    }
+
+    func testVerify_rejectsTamperedId() throws {
+        let signed = try LightEvent.sign(
+            privateKey: testPrivateKey,
+            kind: 1,
+            content: "id tamper test",
+            tags: []
+        )
+        var dict = signed.toDict()
+        // Flip the leading hex nibble so it stays well-formed but wrong.
+        let id = signed.id
+        let flipped = (id.first == "0" ? "1" : "0") + id.dropFirst()
+        dict["id"] = flipped
+        XCTAssertFalse(LightEvent.verify(event: dict),
+                       "a recomputed id mismatch must fail")
+    }
+
+    func testVerify_rejectsTamperedSig() throws {
+        let signed = try LightEvent.sign(
+            privateKey: testPrivateKey,
+            kind: 1,
+            content: "sig tamper test",
+            tags: []
+        )
+        var dict = signed.toDict()
+        let sig = signed.sig
+        let flipped = (sig.first == "0" ? "1" : "0") + sig.dropFirst()
+        dict["sig"] = flipped
+        XCTAssertFalse(LightEvent.verify(event: dict),
+                       "a tampered signature must fail BIP-340 verification")
+    }
+
+    // MARK: - Control-char escaping round-trip
+
+    /// Proves the control-char escaping sweep (C3.1) is internally consistent:
+    /// sign content containing backspace/vertical-tab/form-feed/null, then verify.
+    func testVerify_roundTripControlCharContent() throws {
+        let signed = try LightEvent.sign(
+            privateKey: testPrivateKey,
+            kind: 1,
+            content: "\u{08}\u{0B}\u{0C}\u{00}",
+            tags: []
+        )
+        XCTAssertTrue(LightEvent.verify(event: signed.toDict()),
+                      "control-char content must round-trip through escaping consistently")
+    }
+
+    // MARK: - Malformed input (fail-closed)
+
+    func testVerify_rejectsMissingFields() {
+        let event: [String: Any] = [
+            "kind": 1,
+            "id": "00",
+            "pubkey": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+            // missing created_at, tags, content, sig
+        ]
+        XCTAssertFalse(LightEvent.verify(event: event),
+                       "missing required fields must fail closed")
+    }
+}

--- a/Shared/LightEvent.swift
+++ b/Shared/LightEvent.swift
@@ -13,18 +13,15 @@ struct LightNostrEvent {
 
     func toJSON() -> String {
         let tagsJSON = tags.map { tag in
-            "[" + tag.map { "\"\(escapeJSON($0))\"" }.joined(separator: ",") + "]"
+            "[" + tag.map { "\"\(LightEvent.escapeJSON($0))\"" }.joined(separator: ",") + "]"
         }.joined(separator: ",")
 
-        return "{\"id\":\"\(id)\",\"pubkey\":\"\(pubkey)\",\"created_at\":\(createdAt),\"kind\":\(kind),\"tags\":[\(tagsJSON)],\"content\":\"\(escapeJSON(content))\",\"sig\":\"\(sig)\"}"
+        return "{\"id\":\"\(id)\",\"pubkey\":\"\(pubkey)\",\"created_at\":\(createdAt),\"kind\":\(kind),\"tags\":[\(tagsJSON)],\"content\":\"\(LightEvent.escapeJSON(content))\",\"sig\":\"\(sig)\"}"
     }
 
-    private func escapeJSON(_ str: String) -> String {
-        str.replacingOccurrences(of: "\\", with: "\\\\")
-           .replacingOccurrences(of: "\"", with: "\\\"")
-           .replacingOccurrences(of: "\n", with: "\\n")
-           .replacingOccurrences(of: "\r", with: "\\r")
-           .replacingOccurrences(of: "\t", with: "\\t")
+    func toDict() -> [String: Any] {
+        ["id": id, "pubkey": pubkey, "created_at": createdAt, "kind": kind,
+         "tags": tags, "content": content, "sig": sig]
     }
 }
 
@@ -115,12 +112,66 @@ enum LightEvent {
         return try sign(privateKey: privateKey, kind: kind, content: content, tags: tags, createdAt: createdAt)
     }
 
-    private static func escapeJSON(_ str: String) -> String {
-        str.replacingOccurrences(of: "\\", with: "\\\\")
-           .replacingOccurrences(of: "\"", with: "\\\"")
-           .replacingOccurrences(of: "\n", with: "\\n")
-           .replacingOccurrences(of: "\r", with: "\\r")
-           .replacingOccurrences(of: "\t", with: "\\t")
+    /// NIP-01 string escaping. Shared by `toJSON` (wire bytes), `sign` (id
+    /// computation) and `verify` (id recomputation) so all three agree
+    /// byte-for-byte. Escapes: `"` `\` and the named control chars
+    /// (\n \r \t \b \f); every other control char below 0x20 becomes a
+    /// lowercase `\u00xx` escape. `/`, DEL (0x7F) and all non-ASCII scalars
+    /// pass through unchanged. (Audit C3.1: control-char coverage.)
+    static func escapeJSON(_ str: String) -> String {
+        var out = String()
+        out.reserveCapacity(str.count)
+        for scalar in str.unicodeScalars {
+            switch scalar {
+            case "\\": out += "\\\\"
+            case "\"": out += "\\\""
+            case "\u{08}": out += "\\b"
+            case "\u{09}": out += "\\t"
+            case "\u{0A}": out += "\\n"
+            case "\u{0C}": out += "\\f"
+            case "\u{0D}": out += "\\r"
+            default:
+                if scalar.value < 0x20 {
+                    out += String(format: "\\u%04x", scalar.value)
+                } else {
+                    out.unicodeScalars.append(scalar)
+                }
+            }
+        }
+        return out
+    }
+
+    /// Recompute the event id from its canonical NIP-01 serialization and
+    /// verify the BIP-340 Schnorr signature. Fail-closed: any missing or
+    /// malformed field, an id mismatch, or a bad signature returns false.
+    static func verify(event: [String: Any]) -> Bool {
+        guard let pubkeyHex = event["pubkey"] as? String,
+              let claimedId = event["id"] as? String,
+              let sigHex = event["sig"] as? String,
+              let kind = event["kind"] as? Int,
+              let content = event["content"] as? String else { return false }
+        let ts: Int
+        if let i = event["created_at"] as? Int { ts = i }
+        else if let d = event["created_at"] as? Double { ts = Int(d) }
+        else { return false }
+        let rawTags = (event["tags"] as? [[Any]]) ?? []
+        let tags = rawTags.map { $0.map { "\($0)" } }
+
+        let tagsJSON = tags.map { tag in
+            "[" + tag.map { "\"\(escapeJSON($0))\"" }.joined(separator: ",") + "]"
+        }.joined(separator: ",")
+        let serialized = "[0,\"\(pubkeyHex)\",\(ts),\(kind),[\(tagsJSON)],\"\(escapeJSON(content))\"]"
+        let idHash = CryptoKit.SHA256.hash(data: Data(serialized.utf8))
+        guard Data(idHash).hex == claimedId else { return false }
+
+        guard let pubkeyData = Data(hexString: pubkeyHex), pubkeyData.count == 32,
+              let sigData = Data(hexString: sigHex), sigData.count == 64 else { return false }
+        do {
+            let signature = try P256K.Schnorr.SchnorrSignature(dataRepresentation: sigData)
+            let xonly = P256K.Schnorr.XonlyKey(dataRepresentation: pubkeyData)
+            var msg = Array(Data(idHash))
+            return xonly.isValid(signature, for: &msg)
+        } catch { return false }
     }
 
     private static func generateAuxRand() throws -> Data {

--- a/Shared/LightSigner.swift
+++ b/Shared/LightSigner.swift
@@ -64,6 +64,18 @@ enum LightSigner {
         // bucket — non-fatal but bounded.
         let signerPubkey = (try? LightEvent.pubkeyHex(from: privateKey)) ?? ""
 
+        // Signature verification (path-wide) — PHASE 1: OBSERVE-ONLY. Recompute
+        // the event id + BIP-340 Schnorr verify (LightEvent.verify) and LOG
+        // failures, but do NOT reject yet. This lets us confirm real traffic
+        // from every client verifies cleanly before flipping to hard reject
+        // (Phase 2). A failure means a forged/tampered/replayed-with-freshened-
+        // envelope event OR a client serialization mismatch we must account for.
+        // Runs before dedup so a forged/freshened id can't pollute the dedup
+        // ring or be trusted by the freshness window once enforcement lands.
+        if !LightEvent.verify(event: requestEvent) {
+            logger.error("[LightSigner] SIGCHECK FAIL eid=\((requestEvent["id"] as? String)?.prefix(8) ?? "?", privacy: .public) sender=\(senderPubkey.prefix(8), privacy: .public)")
+        }
+
         // Per-event-id dedupe (audit D.1.1). Both NSE and the foreground
         // relay subscription (Layer 1) call into this function; whichever
         // marks first wins, others skip. Cross-process semantics are lossy


### PR DESCRIPTION
## Summary

Adds path-wide NIP-46 incoming-event **signature verification** in **observe-only** mode (Phase 1), plus the build-infra fix it required.

Today Clave verifies **no signatures** on incoming kind:24133 requests, so the envelope fields (`id`, `created_at`) are unauthenticated — making the dedup + 60s freshness window (audit D.1.1) *soft* against replay. Forgery is still blocked by NIP-44 authenticated-encryption + the pairing check (the core promise holds), but **replay** of captured requests — harmful for the upcoming `logout` method — was unguarded. Counterpart to proxy item B4.1.

## Commits
1. **`feat(security): add LightEvent.verify + complete NIP-01 escaping (C3.1)`** — `LightEvent.verify(event:)` recomputes the event id from the canonical NIP-01 serialization and BIP-340 Schnorr-verifies it, fail-closed. Completes the NIP-01 escaping (audit **C3.1**): collapses the two byte-identical `escapeJSON` copies into one shared static and escapes every control char `< 0x20`. 9 tests incl. an **independent nak/go-nostr vector** (cross-impl conformance, not just round-trip) + tamper rejection for id/sig/created_at/content.
2. **`build: remove in-archive preflight hook; rely on /ship-prep, keep sandbox on`** — the PR #60 preflight Run Script reads an external file that `ENABLE_USER_SCRIPT_SANDBOXING=YES` blocks on *every* build, breaking CLI/test builds. The drift guard it provided ("never ship from unpushed code") is already enforced by `/ship-prep`. Removing the hook keeps script sandboxing **ON** (supply-chain defense) and restores buildable CLI/test runs.

## Behavior
Observe-only: `handleRequest` calls `verify` on every request (before dedup) and **logs `SIGCHECK FAIL`** but does **not reject** — zero user-facing change. A soak confirms no false-rejects across clients before a follow-up flips to hard enforcement (Phase 2).

## Test plan
- `LightEventVerifyTests`: 9/9 pass incl. the independent vector + tamper cases.
- Soak: watch `SIGCHECK` logs across Spectr / noStrudel / Amber / ndk / Coracle; zero fails on genuine traffic = ready for Phase 2.

## Follow-ups
- **Phase 2:** flip observe-only → hard reject after a clean soak (~3 lines).
- The NIP-46 `logout` method builds on this (enforces verification for logout from day one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)