### PR TITLE
NIP-46 logout method

### DIFF
--- a/Clave/AppState+ProxyClient.swift
+++ b/Clave/AppState+ProxyClient.swift
@@ -341,91 +341,18 @@ extension AppState {
     /// leak surfaced during build 33 multi-account smoke test as
     /// "no pair found" log noise during pendingPairOps drains.
     func unpairClientWithProxy(clientPubkey: String, signer: String? = nil) {
-        // Layer 1: the unpaired client's URI relays may no longer be needed
-        // in the foreground sub's set. Refresh.
+        // Layer 1: the unpaired client's URI relays may no longer be needed in
+        // the foreground sub's set. Refresh.
         Task { @MainActor in
             ForegroundRelaySubscription.shared.refreshRelaySet()
         }
-
-        // Capture signer at call-time (default current) so the URLSession
-        // failure closure enqueues the PairOp under the correct account
-        // even if the user-driven account switch races the in-flight request.
+        // Capture signer at call-time (default current) so the retry enqueue
+        // lands under the correct account even if an account switch races.
         let capturedSigner = signer ?? signerPubkeyHex
         logger.notice("[Pair] unpair-client begin client=\(clientPubkey.prefix(8), privacy: .public) signer=\(capturedSigner.prefix(8), privacy: .public)")
-        guard !capturedSigner.isEmpty,
-              let nsec = SharedKeychain.loadNsec(for: capturedSigner) else {
-            logger.error("[Pair] unpair-client abort: empty signer or no nsec in Keychain client=\(clientPubkey.prefix(8), privacy: .public)")
-            return
+        Task {
+            await LightSigner.unpairClientAndQueue(clientPubkey: clientPubkey, signer: capturedSigner)
         }
-        let privateKey: Data
-        do {
-            privateKey = try Bech32.decodeNsec(nsec)
-        } catch {
-            logger.error("[Pair] unpair-client abort: Bech32 decode failed err=\(error.localizedDescription, privacy: .public)")
-            return
-        }
-
-        let proxyURL = SharedConstants.sharedDefaults.string(forKey: SharedConstants.proxyURLKey)
-            ?? SharedConstants.defaultProxyURL
-        let unpairURL = "\(proxyURL)/unpair-client"
-        guard let url = URL(string: unpairURL) else {
-            logger.error("[Pair] unpair-client abort: invalid URL=\(unpairURL, privacy: .public)")
-            return
-        }
-
-        let bodyDict: [String: Any] = ["client_pubkey": clientPubkey]
-        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else {
-            logger.error("[Pair] unpair-client abort: body serialization failed")
-            return
-        }
-        let bodyHash = SHA256.hash(data: bodyData).map { String(format: "%02x", $0) }.joined()
-
-        let authHeader: String
-        do {
-            authHeader = try LightEvent.signNip98(
-                privateKey: privateKey,
-                url: unpairURL,
-                method: "POST",
-                bodySha256Hex: bodyHash
-            )
-        } catch {
-            logger.error("[Pair] unpair-client abort: NIP-98 sign failed err=\(error.localizedDescription, privacy: .public)")
-            return
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.timeoutInterval = 10
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(authHeader, forHTTPHeaderField: "X-Clave-Auth")
-        request.httpBody = bodyData
-
-        URLSession.shared.dataTask(with: request) { _, response, error in
-            let http = response as? HTTPURLResponse
-            if http?.statusCode == 200 {
-                logger.notice("[Pair] unpair-client ok client=\(clientPubkey.prefix(8), privacy: .public) signer=\(capturedSigner.prefix(8), privacy: .public)")
-                return
-            }
-            let statusStr: String
-            if let code = http?.statusCode {
-                statusStr = "\(code)"
-            } else if let error {
-                statusStr = "net-err:\(error.localizedDescription)"
-            } else {
-                statusStr = "no-response"
-            }
-            logger.error("[Pair] unpair-client failed status=\(statusStr, privacy: .public) — queued for retry client=\(clientPubkey.prefix(8), privacy: .public)")
-            let op = PairOp(
-                id: UUID().uuidString,
-                kind: .unpair,
-                clientPubkey: clientPubkey,
-                relayUrls: nil,
-                createdAt: Date().timeIntervalSince1970,
-                failCount: 0,
-                signerPubkeyHex: capturedSigner
-            )
-            SharedStorage.enqueuePendingPairOp(op)
-        }.resume()
     }
 
     /// Drain the pending pair/unpair ops queue. Called on app foreground and

--- a/Clave/Views/Activity/ActivityDetailView.swift
+++ b/Clave/Views/Activity/ActivityDetailView.swift
@@ -400,6 +400,7 @@ struct ActivityDetailView: View {
         case "nip44v3_encrypt":  return "Encrypt (NIP-44 v3)"
         case "nip44v3_decrypt":  return "Decrypt (NIP-44 v3)"
         case "connect":          return "Connect"
+        case "logout":           return "Disconnected"
         default:                 return method
         }
     }

--- a/Clave/Views/Activity/ActivityRowView.swift
+++ b/Clave/Views/Activity/ActivityRowView.swift
@@ -102,6 +102,7 @@ struct ActivityRowView: View {
         case "nip44v3_encrypt":  return "Encrypt (NIP-44 v3)"
         case "nip44v3_decrypt":  return "Decrypt (NIP-44 v3)"
         case "connect":          return "Connect"
+        case "logout":           return "Disconnected"
         default:                 return method
         }
     }

--- a/Clave/Views/Inbox/PendingRequestDetailView.swift
+++ b/Clave/Views/Inbox/PendingRequestDetailView.swift
@@ -369,6 +369,7 @@ struct PendingRequestDetailView: View {
         case "nip44v3_encrypt":  return "Encrypt (NIP-44 v3)"
         case "nip44v3_decrypt":  return "Decrypt (NIP-44 v3)"
         case "connect":          return "Connect"
+        case "logout":           return "Disconnected"
         default:                 return request.method
         }
     }

--- a/ClaveNSE/NotificationService.swift
+++ b/ClaveNSE/NotificationService.swift
@@ -21,6 +21,9 @@ private struct SigningResult {
         )
         case error(String)
         case noEvents
+        /// Informational, user-visible receipt (e.g. a client logout). Unlike
+        /// .success it is NOT blanked — it renders an active banner.
+        case info(title: String, body: String)
     }
     let status: Status
 }
@@ -121,6 +124,12 @@ class NotificationService: UNNotificationServiceExtension {
                 info["pendingRequestId"] = requestId
                 content.userInfo = info
             }
+            contentHandler?(content)
+
+        case .info(let title, let body):
+            content.title = title
+            content.body = body
+            content.interruptionLevel = .active  // override the proxy's passive payload so it actually shows
             contentHandler?(content)
 
         case .success, .noEvents:
@@ -238,6 +247,7 @@ class NotificationService: UNNotificationServiceExtension {
             var lastPendingMethod: String? = nil
             var lastPendingKind: Int? = nil
             var lastPendingRequestId: String? = nil
+            var loggedOutClient: String? = nil
 
             // Process connect requests before anything else so pairing state is
             // established before sign_event/encrypt/decrypt requests in the same batch.
@@ -268,6 +278,16 @@ class NotificationService: UNNotificationServiceExtension {
                         // Layer 1 foreground sub or another NSE wake already
                         // handled this event. No-op.
                         continue
+                    }
+                    if result.status == "blocked" && result.errorMessage == nil {
+                        // Silently dropped (unpaired/stale logout, or a signature-
+                        // verification reject): no banner. Decouple the silent intent
+                        // from the .success-by-elimination fallback so it can't be
+                        // broken by later changes.
+                        continue
+                    }
+                    if result.method == "logout" && result.status == "signed" {
+                        loggedOutClient = result.clientPubkey
                     }
                     handledCount += 1
                     if result.status == "error" {
@@ -315,6 +335,13 @@ class NotificationService: UNNotificationServiceExtension {
                 ))
             } else if let error = lastError {
                 return SigningResult(status: .error(error))
+            } else if let client = loggedOutClient {
+                let name = SharedStorage.getClientPermissions(for: client)?.name
+                    ?? "Client …\(client.suffix(8))"
+                return SigningResult(status: .info(
+                    title: "Disconnected",
+                    body: "\(name) signed out and was removed."
+                ))
             } else {
                 return SigningResult(status: .success)
             }

--- a/ClaveTests/LightSignerLogoutTests.swift
+++ b/ClaveTests/LightSignerLogoutTests.swift
@@ -6,6 +6,79 @@ import XCTest
 /// async path + manual verification.
 final class LightSignerLogoutTests: XCTestCase {
 
+    let testSigner = "logoutSigner"
+    let testClient = "logoutClient"
+
+    override func setUp() { super.setUp(); wipeKeys() }
+    override func tearDown() { wipeKeys(); super.tearDown() }
+
+    private func wipeKeys() {
+        let keys = [
+            SharedConstants.connectedClientsKey,
+            SharedConstants.clientPermissionsKey,
+            SharedConstants.activityLogKey,
+            SharedConstants.pendingPairOpsKey,
+        ]
+        for k in keys { SharedConstants.sharedDefaults.removeObject(forKey: k) }
+    }
+
+    private func seedPairedClient() {
+        let perms = ClientPermissions(
+            pubkey: testClient, trustLevel: .medium, kindOverrides: [:],
+            methodPermissions: ClientPermissions.defaultMethodPermissions,
+            name: "Test Client", url: nil, imageURL: nil,
+            connectedAt: Date().timeIntervalSince1970, lastSeen: Date().timeIntervalSince1970,
+            requestCount: 0, signerPubkeyHex: testSigner)
+        SharedStorage.saveClientPermissions(perms)
+        SharedStorage.setClientRelayUrls(pubkey: testClient, relayUrls: [SharedConstants.relayURL], signer: testSigner)
+    }
+
+    private func seedActivityEntry() {
+        let entry = ActivityEntry(
+            id: "act-1", method: "sign_event", eventKind: 1, clientPubkey: testClient,
+            timestamp: Date().timeIntervalSince1970, status: "signed", errorMessage: nil,
+            signerPubkeyHex: testSigner)
+        SharedStorage.logActivity(entry)
+    }
+
+    func testLogoutTeardown_removesPairAndConnectedRow() async {
+        seedPairedClient()
+        XCTAssertNotNil(SharedStorage.getClientPermissions(signer: testSigner, client: testClient))
+        XCTAssertEqual(SharedStorage.getConnectedClients(for: testSigner).count, 1)
+        await LightSigner.performLogoutTeardown(signerPubkey: testSigner, senderPubkey: testClient)
+        XCTAssertNil(SharedStorage.getClientPermissions(signer: testSigner, client: testClient))
+        XCTAssertEqual(SharedStorage.getConnectedClients(for: testSigner).count, 0)
+    }
+
+    func testLogoutTeardown_retainsActivityLog() async {
+        seedPairedClient(); seedActivityEntry()
+        XCTAssertEqual(SharedStorage.getActivityLog(for: testSigner).count, 1)
+        await LightSigner.performLogoutTeardown(signerPubkey: testSigner, senderPubkey: testClient)
+        XCTAssertEqual(SharedStorage.getActivityLog(for: testSigner).count, 1,
+                       "logout must KEEP the activity log (parity with manual unpair)")
+    }
+
+    /// No reachable proxy in tests → the inline POST fails and falls back to the
+    /// PairOp queue, so the queued op is the observable outcome.
+    func testLogoutTeardown_queuesProxyUnpairOnFailure() async {
+        seedPairedClient()
+        await LightSigner.performLogoutTeardown(signerPubkey: testSigner, senderPubkey: testClient)
+        let ops = SharedStorage.getPendingPairOps()
+        XCTAssertEqual(ops.count, 1)
+        XCTAssertEqual(ops.first?.kind, .unpair)
+        XCTAssertEqual(ops.first?.clientPubkey, testClient)
+        XCTAssertEqual(ops.first?.signerPubkeyHex, testSigner)
+    }
+
+    func testLogoutTeardown_secondCallIsNoOp() async {
+        seedPairedClient()
+        await LightSigner.performLogoutTeardown(signerPubkey: testSigner, senderPubkey: testClient)
+        let afterFirst = SharedStorage.getPendingPairOps().count
+        await LightSigner.performLogoutTeardown(signerPubkey: testSigner, senderPubkey: testClient)
+        XCTAssertEqual(SharedStorage.getPendingPairOps().count, afterFirst,
+                       "second teardown (pair already gone) must not enqueue a duplicate op")
+    }
+
     func testIsLogoutReplay_rejectsFramePredatingPairing() {
         // pairing at t=10_000; a replayed logout from a prior session at t=9_000.
         XCTAssertTrue(LightSigner.isLogoutReplay(eventCreatedAt: 9_000, pairingConnectedAt: 10_000))

--- a/ClaveTests/LightSignerLogoutTests.swift
+++ b/ClaveTests/LightSignerLogoutTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Clave
+
+/// NIP-46 logout — replay-guard coverage. `isLogoutReplay` is pure, tested
+/// directly. The handleRequest gate (which reuses these) is exercised via the
+/// async path + manual verification.
+final class LightSignerLogoutTests: XCTestCase {
+
+    func testIsLogoutReplay_rejectsFramePredatingPairing() {
+        // pairing at t=10_000; a replayed logout from a prior session at t=9_000.
+        XCTAssertTrue(LightSigner.isLogoutReplay(eventCreatedAt: 9_000, pairingConnectedAt: 10_000))
+    }
+
+    func testIsLogoutReplay_acceptsFreshLogout() {
+        // logout sent after pairing (plus normal delay) is honored.
+        XCTAssertFalse(LightSigner.isLogoutReplay(eventCreatedAt: 10_500, pairingConnectedAt: 10_000))
+    }
+
+    func testIsLogoutReplay_toleratesClockSkew() {
+        // logout 100s "before" connectedAt (clock skew) within the 300s tolerance is honored.
+        XCTAssertFalse(LightSigner.isLogoutReplay(eventCreatedAt: 9_900, pairingConnectedAt: 10_000))
+    }
+}

--- a/ClaveTests/LightSignerProcessRequestTests.swift
+++ b/ClaveTests/LightSignerProcessRequestTests.swift
@@ -40,4 +40,32 @@ final class LightSignerProcessRequestTests: XCTestCase {
         XCTAssertFalse(result!.contains("wss://"), "switch_relays result must not contain any wss:// URL")
         XCTAssertFalse(result!.contains(SharedConstants.relayURL), "switch_relays result must not contain SharedConstants.relayURL")
     }
+
+    /// NIP-46 `logout` must return the literal `"ack"` per Amber #460 and the
+    /// nips#2373 proposal (params `[]`, result `"ack"`).
+    func testLogoutReturnsAck() {
+        let privateKey = randomKey()
+        let (result, error) = LightSigner.processRequest(
+            method: "logout",
+            params: [],
+            privateKey: privateKey
+        )
+        XCTAssertEqual(result, "ack", "logout must return the string \"ack\"")
+        XCTAssertNil(error)
+    }
+
+    /// `describe` must advertise `logout` so capability-probing clients know
+    /// Clave honors session teardown.
+    func testDescribeAdvertisesLogout() {
+        let privateKey = randomKey()
+        let (result, error) = LightSigner.processRequest(
+            method: "describe",
+            params: [],
+            privateKey: privateKey
+        )
+        XCTAssertNil(error)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.contains("\"logout\""),
+                      "describe array must include \"logout\"")
+    }
 }

--- a/Shared/LightSigner.swift
+++ b/Shared/LightSigner.swift
@@ -297,6 +297,19 @@ enum LightSigner {
             let perms = SharedStorage.getClientPermissions(signer: signerPubkey, client: senderPubkey)
 
             if perms == nil {
+                // Mirror Amber #460: a logout from a client with no live session
+                // is a no-op — no session to remove, and we surface nothing (no
+                // "ack", no error). "blocked" + nil errorMessage + no
+                // sendErrorResponse → the NSE maps it to a blank/suppressed
+                // notification, so the user's Notification Center stays quiet.
+                if method == "logout" {
+                    logger.notice("[LightSigner] logout from unpaired client — silent no-op")
+                    return RequestResult(
+                        method: method, eventKind: nil, clientPubkey: senderPubkey,
+                        status: "blocked", errorMessage: nil,
+                        v3Kind: v3Kind, v3Scope: v3Scope
+                    )
+                }
                 // Unpaired clients may ONLY send `connect` — everything else (including kind:22242
                 // NIP-42 relay auth) requires a prior successful pair via bunker secret or
                 // nostrconnect handshake. Historical note: we briefly exempted kind:22242 here to
@@ -353,7 +366,11 @@ enum LightSigner {
                         // Malformed v3 request — surface to user, don't auto-approve.
                         allowed = false
                     }
-                case "connect", "ping", "get_public_key", "describe", "switch_relays":
+                case "connect", "ping", "get_public_key", "describe", "switch_relays", "logout":
+                    // logout ends the requesting client's OWN session (keyed by
+                    // senderPubkey) — there is nothing for the user to authorize,
+                    // and gating it would create zombie pairings (client has
+                    // already deleted its keypair per nips#2373). Never prompt.
                     allowed = true
                 default:
                     allowed = true

--- a/Shared/LightSigner.swift
+++ b/Shared/LightSigner.swift
@@ -725,8 +725,16 @@ enum LightSigner {
             // the pairing UI. Validated on TestFlight builds 16+17.
             return ("null", nil)
 
+        case "logout":
+            // NIP-46 session teardown (nips#2373, Amber #460). Returning the
+            // ack string here is all processRequest does — the actual session
+            // removal happens in handleRequest after this ack is published,
+            // because teardown needs signer/sender pubkeys + storage + proxy,
+            // none of which processRequest (a pure fn) has access to.
+            return ("ack", nil)
+
         case "describe":
-            return ("[\"connect\",\"sign_event\",\"get_public_key\",\"ping\",\"nip04_encrypt\",\"nip04_decrypt\",\"nip44_encrypt\",\"nip44_decrypt\",\"nip44v3_encrypt\",\"nip44v3_decrypt\",\"switch_relays\",\"describe\"]", nil)
+            return ("[\"connect\",\"sign_event\",\"get_public_key\",\"ping\",\"nip04_encrypt\",\"nip04_decrypt\",\"nip44_encrypt\",\"nip44_decrypt\",\"nip44v3_encrypt\",\"nip44v3_decrypt\",\"switch_relays\",\"logout\",\"describe\"]", nil)
 
         default:
             return (nil, "Unsupported method: \(method)")

--- a/Shared/LightSigner.swift
+++ b/Shared/LightSigner.swift
@@ -296,6 +296,22 @@ enum LightSigner {
             // client) consent.
             let perms = SharedStorage.getClientPermissions(signer: signerPubkey, client: senderPubkey)
 
+            // Replay guard: honor a paired-client logout only if it postdates the
+            // current pairing. A captured logout replayed after a re-pair would
+            // otherwise silently tear down the fresh session (logout is
+            // auto-allowed). created_at is coerced Double-or-Int (JSONSerialization
+            // may bridge it to a Double-typed NSNumber — the narrow `as? Int`
+            // would return nil and fail OPEN); mirrors the dedup block's coercion.
+            if method == "logout", let perms {
+                let ca = (requestEvent["created_at"] as? Double) ?? Double(requestEvent["created_at"] as? Int ?? 0)
+                if ca > 0, isLogoutReplay(eventCreatedAt: ca, pairingConnectedAt: perms.connectedAt) {
+                    logger.notice("[LightSigner] stale logout (predates pairing) — ignored as replay")
+                    return RequestResult(method: method, eventKind: nil, clientPubkey: senderPubkey,
+                                         status: "blocked", errorMessage: nil,
+                                         v3Kind: v3Kind, v3Scope: v3Scope)
+                }
+            }
+
             if perms == nil {
                 // Mirror Amber #460: a logout from a client with no live session
                 // is a no-op — no session to remove, and we surface nothing (no
@@ -759,6 +775,19 @@ enum LightSigner {
     }
 
     // MARK: - Helpers
+
+    /// Clock-skew tolerance for the logout replay guard. A legit logout always
+    /// postdates its pairing; a replay comes from a prior (earlier) session, so
+    /// a generous tolerance rejects replays without false-rejecting
+    /// skewed-but-legit logouts. Sessions are minutes+ apart in practice.
+    static let logoutReplaySkewTolerance: Double = 300
+
+    /// True if a logout event predates the current pairing (i.e. a replayed
+    /// frame from before a re-pair). Pure — unit-tested directly.
+    static func isLogoutReplay(eventCreatedAt: Double, pairingConnectedAt: Double,
+                               skewTolerance: Double = logoutReplaySkewTolerance) -> Bool {
+        eventCreatedAt < pairingConnectedAt - skewTolerance
+    }
 
     private static func extractEventKind(method: String, params: [String]) -> Int? {
         guard method == "sign_event", let eventJson = params.first,

--- a/Shared/LightSigner.swift
+++ b/Shared/LightSigner.swift
@@ -1,5 +1,6 @@
 import Foundation
 import os.log
+import CryptoKit
 
 private let logger = Logger(subsystem: "dev.nostr.clave", category: "signer")
 
@@ -560,6 +561,14 @@ enum LightSigner {
             signedEventJSON = json
         }
 
+        // Ack-gated logout teardown (Amber #460 pattern: remove the session only
+        // after the "ack" actually went out). `status == "signed"` means a relay
+        // accepted the response; if publish failed we leave the session intact so
+        // the client can retry.
+        if method == "logout", status == "signed" {
+            await performLogoutTeardown(signerPubkey: signerPubkey, senderPubkey: senderPubkey)
+        }
+
         let result = RequestResult(method: method, eventKind: eventKind, clientPubkey: senderPubkey,
                                    status: status, errorMessage: errorMsg,
                                    signedEventId: signedEventId, signedSummary: signedSummary,
@@ -787,6 +796,70 @@ enum LightSigner {
     static func isLogoutReplay(eventCreatedAt: Double, pairingConnectedAt: Double,
                                skewTolerance: Double = logoutReplaySkewTolerance) -> Bool {
         eventCreatedAt < pairingConnectedAt - skewTolerance
+    }
+
+    // MARK: - Logout teardown
+
+    /// POST /unpair-client (NIP-98 signed). Pure attempt — returns success,
+    /// does NOT touch the retry queue (the caller owns that). 6s timeout so an
+    /// NSE-context await can't approach the 30s extension budget.
+    static func sendProxyUnpair(clientPubkey: String, signer: String) async -> Bool {
+        guard !signer.isEmpty, let nsec = SharedKeychain.loadNsec(for: signer) else { return false }
+        let privateKey: Data
+        do { privateKey = try Bech32.decodeNsec(nsec) } catch { return false }
+        let proxyURL = SharedConstants.sharedDefaults.string(forKey: SharedConstants.proxyURLKey)
+            ?? SharedConstants.defaultProxyURL
+        let unpairURL = "\(proxyURL)/unpair-client"
+        guard let url = URL(string: unpairURL) else { return false }
+        let bodyDict: [String: Any] = ["client_pubkey": clientPubkey]
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict) else { return false }
+        let bodyHash = SHA256.hash(data: bodyData).map { String(format: "%02x", $0) }.joined()
+        let authHeader: String
+        do {
+            authHeader = try LightEvent.signNip98(privateKey: privateKey, url: unpairURL,
+                                                  method: "POST", bodySha256Hex: bodyHash)
+        } catch { return false }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 6
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(authHeader, forHTTPHeaderField: "X-Clave-Auth")
+        request.httpBody = bodyData
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            return (response as? HTTPURLResponse)?.statusCode == 200
+        } catch { return false }
+    }
+
+    /// Queue the unpair op FIRST (guarantees recovery if we're killed mid-POST
+    /// or the POST fails), attempt the POST, and clear the queued op only on a
+    /// 200. Shared by AppState's foreground unpair and the NSE logout teardown.
+    static func unpairClientAndQueue(clientPubkey: String, signer: String) async {
+        let op = PairOp(id: UUID().uuidString, kind: .unpair, clientPubkey: clientPubkey,
+                        relayUrls: nil, createdAt: Date().timeIntervalSince1970,
+                        failCount: 0, signerPubkeyHex: signer)
+        SharedStorage.enqueuePendingPairOp(op)
+        if await sendProxyUnpair(clientPubkey: clientPubkey, signer: signer) {
+            SharedStorage.removePendingPairOp(id: op.id)
+            logger.notice("[LightSigner] proxy unpair ok client=\(clientPubkey.prefix(8), privacy: .public)")
+        } else {
+            logger.notice("[LightSigner] proxy unpair deferred to queue client=\(clientPubkey.prefix(8), privacy: .public)")
+        }
+    }
+
+    /// Tear down a client's session on logout. Idempotent + race-reducing (the
+    /// had-guard skips a duplicate teardown if a racing process — NSE + the
+    /// foreground sub catching the same event — already removed the pair;
+    /// residual double-teardown is benign by idempotency). Keeps the activity
+    /// log (parity with the user-tap unpair; deliberately NOT Amber's history
+    /// wipe).
+    static func performLogoutTeardown(signerPubkey: String, senderPubkey: String) async {
+        guard SharedStorage.getClientPermissions(signer: signerPubkey, client: senderPubkey) != nil else {
+            logger.notice("[LightSigner] logout teardown skipped — pair already gone")
+            return
+        }
+        SharedStorage.removeClientPermissions(signer: signerPubkey, client: senderPubkey)
+        await unpairClientAndQueue(clientPubkey: senderPubkey, signer: signerPubkey)
     }
 
     private static func extractEventKind(method: String, params: [String]) -> Int? {


### PR DESCRIPTION
## Summary
Implements the NIP-46 `logout` method (nips#2373, mirrors [Amber #460](https://github.com/greenart7c3/Amber/pull/460)): a client ends its own remote-signer session. Clave acks (`"ack"`), removes the pair (keeps the activity log), and tells the proxy to stop forwarding — fired directly from the NSE.

## What it does
- `logout` → `"ack"`, advertised in `describe`.
- Auto-allowed (a client can only end its OWN session); an unpaired-client logout is a silent no-op.
- **Ack-gated teardown** — remove the pair only after a relay accepts the ack; **keeps the activity log** (parity with manual unpair, not Amber's history wipe).
- **NSE-direct proxy unpair** with optimistic `PairOp` queue — closes the forwarding window immediately and survives a mid-POST process kill. The existing manual unpair now shares this safer path.
- **Replay guard** — rejects a stale logout that predates the current pairing (rests on the enforced signature verification already on `main`).
- "Disconnected" activity label + NSE receipt banner.

## Tests
7 new logout tests (3 replay-guard + 4 teardown). The full `ClaveTests` suite is green **except 2 pre-existing crashes** — `AppStateMultiAccountTests.testReinstallRecovery_*` — which reproduce on `main` with none of this code and are tracked separately (a Swift isolated-deinit double-free at test teardown, unrelated to logout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)