### PR TITLE
chore: bump build number to 97

### DIFF
--- a/Clave.xcodeproj/project.pbxproj
+++ b/Clave.xcodeproj/project.pbxproj
@@ -8,8 +8,16 @@
 
 /* Begin PBXBuildFile section */
 		006B17A84C114EDF9B129CAE /* NostrConnectParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B139A8E147475F9B40B3D5 /* NostrConnectParser.swift */; };
+		050F5CF39475EE32A8E8E333 /* NIP44v3Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A86BF0CB2C7C281D0C2C2FA /* NIP44v3Context.swift */; };
+		2656E4793FC1410AA7512BC3 /* NIP44v3Ciphertext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE923EA7CC2C467139F8FFC7 /* NIP44v3Ciphertext.swift */; };
+		41C3DADD71B490E633DC5BFA /* NIP44v3Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF1ED9FB92F8DE75C7E1A91 /* NIP44v3Padding.swift */; };
+		46B7985DBC947BB035033D3E /* NIP44v3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A86C31C5FB323E8838E1B3B /* NIP44v3.swift */; };
 		4963A6373F0641F1B1A1455A330BCB5B /* DeeplinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7835E9DD22C448C3893D6D945AFFEA16 /* DeeplinkRouter.swift */; };
+		4B1643442A79CAA622E1502E /* NIP44v3Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD29F2B337BCFABFDB3D1E90 /* NIP44v3Keys.swift */; };
+		5990DFA042774D3469516579 /* NIP44v3Ciphertext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE923EA7CC2C467139F8FFC7 /* NIP44v3Ciphertext.swift */; };
 		6D2C503B9EF64C8EA5101CDB /* NostrConnectParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B139A8E147475F9B40B3D5 /* NostrConnectParser.swift */; };
+		710C75E3B08ADB337291508D /* NIP44v3Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3FF06C29401E5957B815C4 /* NIP44v3Encryption.swift */; };
+		878E90BF41E588CE953B1DD9 /* NIP44v3Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3FF06C29401E5957B815C4 /* NIP44v3Encryption.swift */; };
 		AE01F2A3B4C5D6E700000002 /* ActivitySummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE01F2A3B4C5D6E700000001 /* ActivitySummary.swift */; };
 		AE01F2A3B4C5D6E700000003 /* ActivitySummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE01F2A3B4C5D6E700000001 /* ActivitySummary.swift */; };
 		AE01F2A3B4C5D6E700000005 /* Nip19.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE01F2A3B4C5D6E700000004 /* Nip19.swift */; };
@@ -19,13 +27,17 @@
 		B0EBA01E2F90AB01000A0003 /* PendingApprovalBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0EBA01E2F90AB01000A0002 /* PendingApprovalBanner.swift */; };
 		B2551C1A4D99451B8AABCA1763DF333C /* DeeplinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7835E9DD22C448C3893D6D945AFFEA16 /* DeeplinkRouter.swift */; };
 		BD247C1AD3A7497E8DF29530 /* ClientPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894FE9FF88CD485ABCD31C05 /* ClientPermissions.swift */; };
+		C1917DBCE42E856941D82504 /* NIP44v3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A86C31C5FB323E8838E1B3B /* NIP44v3.swift */; };
 		C1A4F2B3C5D6E700000011 /* AccountTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A4F2B3C5D6E700000010 /* AccountTheme.swift */; };
+		C360E69B13B62E1A5DD1415E /* NIP44v3Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD29F2B337BCFABFDB3D1E90 /* NIP44v3Keys.swift */; };
+		CA89C798FD2DB7101C82A779 /* NIP44v3Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A86BF0CB2C7C281D0C2C2FA /* NIP44v3Context.swift */; };
 		DD90DE0C2D8944D08B23C606 /* ClientPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894FE9FF88CD485ABCD31C05 /* ClientPermissions.swift */; };
 		DE7E10B2DE7E10B2DE7E10B2 /* DeveloperSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10B1DE7E10B1DE7E10B1 /* DeveloperSettings.swift */; };
 		DE7E10B3DE7E10B3DE7E10B3 /* DeveloperSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10B1DE7E10B1DE7E10B1 /* DeveloperSettings.swift */; };
 		DE7E10C2DE7E10C2DE7E10C2 /* LogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10C1DE7E10C1DE7E10C1 /* LogExporter.swift */; };
 		DE7E10C3DE7E10C3DE7E10C3 /* LogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10C1DE7E10C1DE7E10C1 /* LogExporter.swift */; };
 		DE7E10C5DE7E10C5DE7E10C5 /* RelayUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E10C4DE7E10C4DE7E10C4 /* RelayUtils.swift */; };
+		E6FE23FC16624C5965E0151C /* NIP44v3Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF1ED9FB92F8DE75C7E1A91 /* NIP44v3Padding.swift */; };
 		EF1963B89F3A6472380F1E0A /* LightRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D7A5B2F8BD020005A6545 /* LightRelay.swift */; };
 		EF251FEC744434349FD7256D /* P256K in Frameworks */ = {isa = PBXBuildFile; productRef = EF609A96DAD7E5693CA7EE4D /* P256K */; };
 		EF304CFAA8D958E7CCDF01AD /* LightCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D7A592F8BD020005A6545 /* LightCrypto.swift */; };
@@ -49,18 +61,6 @@
 		EFC7FD75109694C0A7F86D26 /* SharedModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFCA55B463A619311A35AF3C /* SharedModels.swift */; };
 		EFE12D1EC4CE48622767D427 /* SharedStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEE4316AC522CDDA35AFAC1 /* SharedStorage.swift */; };
 		F60FCE012F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60FCE002F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift */; };
-		C1917DBCE42E856941D82504 /* NIP44v3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A86C31C5FB323E8838E1B3B /* NIP44v3.swift */; };
-		46B7985DBC947BB035033D3E /* NIP44v3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A86C31C5FB323E8838E1B3B /* NIP44v3.swift */; };
-		41C3DADD71B490E633DC5BFA /* NIP44v3Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF1ED9FB92F8DE75C7E1A91 /* NIP44v3Padding.swift */; };
-		E6FE23FC16624C5965E0151C /* NIP44v3Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF1ED9FB92F8DE75C7E1A91 /* NIP44v3Padding.swift */; };
-		C360E69B13B62E1A5DD1415E /* NIP44v3Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD29F2B337BCFABFDB3D1E90 /* NIP44v3Keys.swift */; };
-		4B1643442A79CAA622E1502E /* NIP44v3Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD29F2B337BCFABFDB3D1E90 /* NIP44v3Keys.swift */; };
-		878E90BF41E588CE953B1DD9 /* NIP44v3Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3FF06C29401E5957B815C4 /* NIP44v3Encryption.swift */; };
-		710C75E3B08ADB337291508D /* NIP44v3Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3FF06C29401E5957B815C4 /* NIP44v3Encryption.swift */; };
-		2656E4793FC1410AA7512BC3 /* NIP44v3Ciphertext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE923EA7CC2C467139F8FFC7 /* NIP44v3Ciphertext.swift */; };
-		5990DFA042774D3469516579 /* NIP44v3Ciphertext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE923EA7CC2C467139F8FFC7 /* NIP44v3Ciphertext.swift */; };
-		050F5CF39475EE32A8E8E333 /* NIP44v3Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A86BF0CB2C7C281D0C2C2FA /* NIP44v3Context.swift */; };
-		CA89C798FD2DB7101C82A779 /* NIP44v3Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A86BF0CB2C7C281D0C2C2FA /* NIP44v3Context.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -103,13 +103,19 @@
 
 /* Begin PBXFileReference section */
 		34B139A8E147475F9B40B3D5 /* NostrConnectParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrConnectParser.swift; sourceTree = "<group>"; };
+		6E3FF06C29401E5957B815C4 /* NIP44v3Encryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIP44v3Encryption.swift; sourceTree = "<group>"; };
 		7835E9DD22C448C3893D6D945AFFEA16 /* DeeplinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkRouter.swift; sourceTree = "<group>"; };
+		7A86BF0CB2C7C281D0C2C2FA /* NIP44v3Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIP44v3Context.swift; sourceTree = "<group>"; };
 		894FE9FF88CD485ABCD31C05 /* ClientPermissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientPermissions.swift; sourceTree = "<group>"; };
+		9A86C31C5FB323E8838E1B3B /* NIP44v3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIP44v3.swift; sourceTree = "<group>"; };
 		AE01F2A3B4C5D6E700000001 /* ActivitySummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivitySummary.swift; sourceTree = "<group>"; };
 		AE01F2A3B4C5D6E700000004 /* Nip19.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Nip19.swift; sourceTree = "<group>"; };
 		AE01F2A3B4C5D6E700000007 /* SharedKeychain+Enumeration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharedKeychain+Enumeration.swift"; sourceTree = "<group>"; };
 		B0EBA01E2F90AB01000A0002 /* PendingApprovalBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingApprovalBanner.swift; sourceTree = "<group>"; };
 		C1A4F2B3C5D6E700000010 /* AccountTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountTheme.swift; sourceTree = "<group>"; };
+		CE923EA7CC2C467139F8FFC7 /* NIP44v3Ciphertext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIP44v3Ciphertext.swift; sourceTree = "<group>"; };
+		DBF1ED9FB92F8DE75C7E1A91 /* NIP44v3Padding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIP44v3Padding.swift; sourceTree = "<group>"; };
+		DD29F2B337BCFABFDB3D1E90 /* NIP44v3Keys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIP44v3Keys.swift; sourceTree = "<group>"; };
 		DE7E10B1DE7E10B1DE7E10B1 /* DeveloperSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperSettings.swift; sourceTree = "<group>"; };
 		DE7E10C1DE7E10C1DE7E10C1 /* LogExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogExporter.swift; sourceTree = "<group>"; };
 		DE7E10C4DE7E10C4DE7E10C4 /* RelayUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayUtils.swift; sourceTree = "<group>"; };
@@ -127,12 +133,6 @@
 		EFCA55B463A619311A35AF3C /* SharedModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedModels.swift; sourceTree = "<group>"; };
 		EFEE4316AC522CDDA35AFAC1 /* SharedStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStorage.swift; sourceTree = "<group>"; };
 		F60FCE002F8BCAE3000FAC0A /* ForegroundRelaySubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForegroundRelaySubscription.swift; sourceTree = "<group>"; };
-		9A86C31C5FB323E8838E1B3B /* NIP44v3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIP44v3.swift; sourceTree = "<group>"; };
-		DBF1ED9FB92F8DE75C7E1A91 /* NIP44v3Padding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIP44v3Padding.swift; sourceTree = "<group>"; };
-		DD29F2B337BCFABFDB3D1E90 /* NIP44v3Keys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIP44v3Keys.swift; sourceTree = "<group>"; };
-		6E3FF06C29401E5957B815C4 /* NIP44v3Encryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIP44v3Encryption.swift; sourceTree = "<group>"; };
-		CE923EA7CC2C467139F8FFC7 /* NIP44v3Ciphertext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIP44v3Ciphertext.swift; sourceTree = "<group>"; };
-		7A86BF0CB2C7C281D0C2C2FA /* NIP44v3Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIP44v3Context.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -683,7 +683,7 @@
 				CODE_SIGN_ENTITLEMENTS = Clave/Clave.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = 944AF56S27;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -721,7 +721,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 944AF56S27;
 				ENABLE_PREVIEWS = YES;
@@ -757,7 +757,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = 944AF56S27;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
@@ -779,7 +779,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = 944AF56S27;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
@@ -800,7 +800,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = 944AF56S27;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 0.2.0;
@@ -820,7 +820,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = 944AF56S27;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 0.2.0;
@@ -841,7 +841,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ClaveNSE/ClaveNSE.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = 944AF56S27;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ClaveNSE/Info.plist;
@@ -872,7 +872,7 @@
 				CODE_SIGN_ENTITLEMENTS = ClaveNSE/ClaveNSE.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 944AF56S27;
 				GENERATE_INFOPLIST_FILE = YES;


### PR DESCRIPTION
Build bump for the NIP-46 logout internal-TestFlight build (#64). No code change — CURRENT_PROJECT_VERSION 96→97 across all 8 target/config entries.