### PR TITLE
docs: add outreach plan, talking points & volunteer playbook + status refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Your nsec never leaves the device. You control which clients can sign which even
 
 ## Status
 
-**Beta.** TestFlight external beta live — use a throwaway nsec for now, not your main key.
+**Beta.** TestFlight external beta live, with months of real-world use behind it. Clave holds your real key the way any signer does — the point is that it becomes the *single* place your key lives, instead of the many copies you create by pasting your nsec into every client. Treat that decision with the same care you'd give any app you trust with your nsec; an independent third-party security audit is on the roadmap (it depends on funding and time), and until then the signing path is fully open source and has had an internal audit. New to it and cautious? Pairing a secondary key first is a perfectly reasonable way to kick the tires.
 
 What works end-to-end:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ What works end-to-end:
 - **NIP-46 methods:** `connect`, `sign_event`, `get_public_key`, `ping`, `describe`, `switch_relays`, `logout`, `nip04_encrypt`, `nip04_decrypt`, `nip44_encrypt`, `nip44_decrypt`, `nip44v3_encrypt`, `nip44v3_decrypt`
 - **Incoming signature verification** — every incoming request's signature is verified before dispatch
 - **Activity log + client detail view** — rename, change trust, review per-client history, unpair
-- **Verified ✅:** Nostur, Primal (web), Coracle, Jumble, noStrudel, Spectr, fevela.me, zap.cooking, YakiHonne — see [docs/nip46-compatibility.md](docs/nip46-compatibility.md) for per-client caveats, library-family notes, and the triage guide.
+- **Verified ✅:** Nostur, Primal (web), Coracle, Jumble, noStrudel, Jank, fevela.me, zap.cooking, YakiHonne — see [docs/nip46-compatibility.md](docs/nip46-compatibility.md) for per-client caveats, library-family notes, and the triage guide.
 
 Known limitations:
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ Your nsec never leaves the device. You control which clients can sign which even
 What works end-to-end:
 
 - **Both pairing flows** — `bunker://` (Clave generates URI) and `nostrconnect://` (client generates URI, Clave approves)
+- **Multiple accounts** — hold several keys, switch accounts in place, and pair a client with many accounts in one flow via the opt-in `accounts=multi` nostrconnect extension (see [docs/integrations.md](docs/integrations.md))
 - **Per-client permissions** — Full / Medium / Low trust with per-kind overrides; protected kinds (0, 3, 5, 10002, 30078) require approval on Medium trust
-- **NIP-46 methods:** `connect`, `sign_event`, `get_public_key`, `ping`, `describe`, `switch_relays`, `nip04_encrypt`, `nip04_decrypt`, `nip44_encrypt`, `nip44_decrypt`
+- **Context-aware approvals (NIP-44 v3)** — v3 encrypt/decrypt requests carry a `(kind, scope)` context bound into the MAC, so approval prompts show what an app is actually touching; "always allow" grants are stored per `(method, kind, scope)`
+- **NIP-46 methods:** `connect`, `sign_event`, `get_public_key`, `ping`, `describe`, `switch_relays`, `logout`, `nip04_encrypt`, `nip04_decrypt`, `nip44_encrypt`, `nip44_decrypt`, `nip44v3_encrypt`, `nip44v3_decrypt`
+- **Incoming signature verification** — every incoming request's signature is verified before dispatch
 - **Activity log + client detail view** — rename, change trust, review per-client history, unpair
-- **Verified ✅:** Nostur, fevela.me. Several other clients work with caveats — see [docs/nip46-compatibility.md](docs/nip46-compatibility.md) for the full per-client matrix, library-family notes, and triage guide.
+- **Verified ✅:** Nostur, Primal (web), Coracle, Jumble, noStrudel, Spectr, fevela.me, zap.cooking, YakiHonne — see [docs/nip46-compatibility.md](docs/nip46-compatibility.md) for per-client caveats, library-family notes, and the triage guide.
 
 Known limitations:
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -74,7 +74,7 @@ The standard NIP-46 client library pattern is "subscribe, resolve on first match
 - For each received ack: validate `echoed_secret` matches the URI secret. Parse optional `name` / `picture` / `total`. Store the `(signer_pk, name, picture)` tuple as one of the user's accounts.
 - On `count == total` (auto-finalize) OR window expiry OR user-tapped Done: close the subscription and surface the resulting accounts list to the user.
 
-A reference implementation lives in Spectr at `src/providers/NostrProvider/login-flows.ts` (function `nostrConnectionLoginMulti`). Spectr targets `nostr-tools` underneath; the accumulator overrides the library's first-ack-completes default.
+A reference implementation lives in the Spectr codebase (shipped as the **Jank** app, https://jank.army) at `src/providers/NostrProvider/login-flows.ts` (function `nostrConnectionLoginMulti`). Spectr targets `nostr-tools` underneath; the accumulator overrides the library's first-ack-completes default.
 
 ### Show progress while listening
 

--- a/docs/outreach/social-media-plan.md
+++ b/docs/outreach/social-media-plan.md
@@ -6,12 +6,14 @@ _Audience: maintainer. Companion docs: [talking-points.md](talking-points.md) (m
 
 In priority order:
 
-1. **Grow the TestFlight beta** with the right testers — people who understand "throwaway nsec only" and will file useful reports.
+1. **Grow the TestFlight beta** with the right testers — people who understand the trade-off (one signer holding your key beats N clients holding copies) and will file useful reports.
 2. **Educate on NIP-46 / key hygiene** so the market for a signer exists. Most Nostr users still paste their nsec into clients; they don't know there's a problem to solve.
 3. **Recruit client developers** — every row added to `docs/nip46-compatibility.md` is worth more than a hundred likes. The `accounts=multi` extension also needs client adoption before the NIP draft.
-4. **Build trust in the security posture** by being radically honest: open source, audited, but beta — and the proxy's metadata visibility stated plainly.
+4. **Build trust in the security posture** by being radically honest: open source, internally audited (independent third-party audit on the roadmap), in real-world use for months, still TestFlight beta — and the proxy's metadata visibility stated plainly.
 
-Explicit non-goal right now: mass-market growth. Clave is beta and pinned to one relay for bunker flow; a viral spike of normies pasting their main nsec in would be a disaster, not a win.
+Explicit non-goal right now: mass-market growth. Clave is still beta and pinned to one relay for bunker flow; chasing a viral spike of non-technical users before the App Store release and the third-party audit would outrun what the infrastructure and support can absorb.
+
+Note on key guidance: the messaging across these docs has moved off the old "throwaway key only" rule to an **informed-choice framing** — Clave holds your real key like any signer does, and the win is one attack surface instead of many. Recruitment posts still name the honest caveats (beta, independent audit pending); they just no longer scold testers into a throwaway key.
 
 ## Channels
 
@@ -56,13 +58,13 @@ Already in place: brand npub, public TestFlight invite link, clave.casa as the l
 
 **Week 1 — foundation.** Set up the volunteer's Clave pairing to the brand npub (the dogfood story above). Publish a pinned "what is Clave" thread (talking-points doc has the copy). Volunteer practices with 2–3 education posts.
 
-**Week 2 — beta recruitment.** TestFlight call-to-action posts — every single one carries the throwaway-nsec caveat, no exceptions. Lead with the breadth of the verified-client list (nine clients people actually use). Short screen recording of bunker pairing → first signed note.
+**Week 2 — beta recruitment.** TestFlight call-to-action posts — each one carries the honest caveats (still beta, independent audit on the roadmap) in the informed-choice framing, not a throwaway-key scold. Lead with the breadth of the verified-client list (nine clients people actually use). Short screen recording of bunker pairing → first signed note.
 
 **Week 3 — multi-account.** Headline campaign: "one pairing, all your accounts." Demo video of the multi-account picker with Spectr; consumer posts from the library; maintainer publishes the `accounts=multi` write-up for devs (Stacker News or GitHub Discussion) and the volunteer amplifies.
 
 **Week 4 — education series + dev outreach.** "Key hygiene week": one post per day on a single idea (key in N apps = N attack surfaces; keys can't rotate; what a remote signer is; what the proxy can and can't see; how to check per-client permissions). Close with the interop-issue call: "found a client that doesn't pair? Tell us, we triage signer-side vs client-side honestly" — the four-bucket triage taxonomy is genuinely differentiating; most projects blame the other side, you publish the analysis.
 
-After day 30: settle into the steady cadence, one campaign per month (next candidates: per-client demo series, NIP-draft filing for `accounts=multi`, the main-key-readiness announcement when the maintainer calls it, self-hosting story when `docs/SELF-HOSTING.md` lands).
+After day 30: settle into the steady cadence, one campaign per month (next candidates: per-client demo series, NIP-draft filing for `accounts=multi`, the independent third-party audit announcement when it completes, self-hosting story when `docs/SELF-HOSTING.md` lands).
 
 ## What success looks like
 
@@ -75,7 +77,7 @@ Track monthly, keep it lightweight:
 
 ## Risks this plan manages
 
-- **Beta over-promotion** → every recruitment post carries the throwaway-nsec caveat; growth is deliberately capped to testers.
-- **Security-claim inflation** → the talking-points doc has an explicit "never say" list; volunteer escalates all security questions beyond the approved FAQ.
+- **Beta over-promotion** → recruitment posts carry the honest caveats (still beta, independent audit on the roadmap) in informed-choice framing; growth is deliberately paced ahead of the App Store release.
+- **Security-claim inflation** → the talking-points doc has an explicit "never say" list (including: never imply the independent third-party audit has happened, never give a flat "safe for your main key" guarantee); volunteer escalates all security questions beyond the approved FAQ.
 - **Vulnerability reports arriving via social DMs** → playbook has a verbatim redirect-to-SECURITY.md template; volunteer never discusses publicly.
 - **Volunteer account compromise** → volunteer never holds the brand key (Clave pairing model); blast radius is unpair-and-done.

--- a/docs/outreach/social-media-plan.md
+++ b/docs/outreach/social-media-plan.md
@@ -60,7 +60,7 @@ Already in place: brand npub, public TestFlight invite link, clave.casa as the l
 
 **Week 2 — beta recruitment.** TestFlight call-to-action posts — each one carries the honest caveats (still beta, independent audit on the roadmap) in the informed-choice framing, not a throwaway-key scold. Lead with the breadth of the verified-client list (nine clients people actually use). Short screen recording of bunker pairing → first signed note.
 
-**Week 3 — multi-account.** Headline campaign: "one pairing, all your accounts." Demo video of the multi-account picker with Spectr; consumer posts from the library; maintainer publishes the `accounts=multi` write-up for devs (Stacker News or GitHub Discussion) and the volunteer amplifies.
+**Week 3 — multi-account.** Headline campaign: "one pairing, all your accounts." Demo video of the multi-account picker with Jank (jank.army); consumer posts from the library; maintainer publishes the `accounts=multi` write-up for devs (Stacker News or GitHub Discussion) and the volunteer amplifies.
 
 **Week 4 — education series + dev outreach.** "Key hygiene week": one post per day on a single idea (key in N apps = N attack surfaces; keys can't rotate; what a remote signer is; what the proxy can and can't see; how to check per-client permissions). Close with the interop-issue call: "found a client that doesn't pair? Tell us, we triage signer-side vs client-side honestly" — the four-bucket triage taxonomy is genuinely differentiating; most projects blame the other side, you publish the analysis.
 

--- a/docs/outreach/social-media-plan.md
+++ b/docs/outreach/social-media-plan.md
@@ -17,8 +17,8 @@ Explicit non-goal right now: mass-market growth. Clave is beta and pinned to one
 
 | Channel | Role | Who runs it |
 |---|---|---|
-| **Nostr (brand npub)** | Primary. The audience is literally Nostr users, and posting from a Clave-secured account is the product demo. | Volunteer (day-to-day), maintainer (releases, technical threads) |
-| **X/Twitter** | Reach beyond Nostr — bitcoin/privacy crowd, iOS devs. Cross-post the best 2–3 Nostr posts per week. | Volunteer |
+| **Nostr (brand npub)** | Primary. The audience is literally Nostr users, and posting from a Clave-secured account is the product demo. ✅ npub exists | Volunteer (day-to-day), maintainer (releases, technical threads) |
+| **X/Twitter** | Reach beyond Nostr — bitcoin/privacy crowd, iOS devs. Cross-post the best 2–3 Nostr posts per week. ⚠️ No account yet — create when bandwidth allows; Nostr comes first | Volunteer |
 | **GitHub** (releases, Discussions) | Developer channel. Release notes, interop changelog, `accounts=multi` spec discussion. | Maintainer only |
 | **Stacker News / r/nostr** | Occasional long-form: launch-style posts, architecture write-ups. Once or twice a month max. | Maintainer drafts, volunteer can repost |
 | **Nostr dev group chats** (Telegram/SimpleX) | Interop coordination with client devs. Technical, relationship-driven. | Maintainer only |
@@ -50,15 +50,19 @@ Rule of thumb: education and community posts can run on the volunteer's own judg
 
 ## First 30 days
 
-**Week 1 — foundation.** Set up brand npub + Clave pairing for the volunteer (the dogfood story above). Publish a pinned "what is Clave" thread (talking-points doc has the copy). Volunteer practices with 2–3 education posts.
+Already in place: brand npub, public TestFlight invite link, clave.casa as the link-in-bio destination. Still needed: the volunteer's Clave pairing, an X account (optional, later), and a docs refresh (below).
 
-**Week 2 — beta recruitment.** TestFlight call-to-action posts — every single one carries the throwaway-nsec caveat, no exceptions. Target Nostur users specifically ("verified ✅"). Short screen recording of bunker pairing → first signed note.
+**Week 0 prerequisite — refresh the public docs outreach points to.** The README's verified list ("Nostur, fevela.me") and the compatibility matrix (statuses from build ~29; app is at build 99) undersell the current state — nine clients are verified, multi-account has shipped. Posts will link to these docs; they need to agree with the posts before the recruitment push.
 
-**Week 3 — education series.** "Key hygiene week": one post per day on a single idea (key in N apps = N attack surfaces; keys can't rotate; what a remote signer is; what the proxy can and can't see; how to check per-client permissions). Honest, no FUD about specific clients.
+**Week 1 — foundation.** Set up the volunteer's Clave pairing to the brand npub (the dogfood story above). Publish a pinned "what is Clave" thread (talking-points doc has the copy). Volunteer practices with 2–3 education posts.
 
-**Week 4 — developer outreach.** Maintainer publishes an `accounts=multi` write-up (Stacker News or GitHub Discussion); volunteer amplifies. Post the interop-issue template link: "found a client that doesn't pair? Tell us, we triage signer-side vs client-side honestly." The four-bucket triage taxonomy from the compatibility doc is genuinely differentiating — most projects blame the other side; you publish the analysis.
+**Week 2 — beta recruitment.** TestFlight call-to-action posts — every single one carries the throwaway-nsec caveat, no exceptions. Lead with the breadth of the verified-client list (nine clients people actually use). Short screen recording of bunker pairing → first signed note.
 
-After day 30: settle into the steady cadence, one campaign per month (next candidates: per-client demo series, multi-account launch when the NIP draft files, self-hosting story when `docs/SELF-HOSTING.md` lands).
+**Week 3 — multi-account.** Headline campaign: "one pairing, all your accounts." Demo video of the multi-account picker with Spectr; consumer posts from the library; maintainer publishes the `accounts=multi` write-up for devs (Stacker News or GitHub Discussion) and the volunteer amplifies.
+
+**Week 4 — education series + dev outreach.** "Key hygiene week": one post per day on a single idea (key in N apps = N attack surfaces; keys can't rotate; what a remote signer is; what the proxy can and can't see; how to check per-client permissions). Close with the interop-issue call: "found a client that doesn't pair? Tell us, we triage signer-side vs client-side honestly" — the four-bucket triage taxonomy is genuinely differentiating; most projects blame the other side, you publish the analysis.
+
+After day 30: settle into the steady cadence, one campaign per month (next candidates: per-client demo series, NIP-draft filing for `accounts=multi`, the main-key-readiness announcement when the maintainer calls it, self-hosting story when `docs/SELF-HOSTING.md` lands).
 
 ## What success looks like
 

--- a/docs/outreach/social-media-plan.md
+++ b/docs/outreach/social-media-plan.md
@@ -1,0 +1,77 @@
+# Clave social media & outreach plan
+
+_Audience: maintainer. Companion docs: [talking-points.md](talking-points.md) (message reference for anyone posting) and [volunteer-playbook.md](volunteer-playbook.md) (the doc you hand to the volunteer)._
+
+## Goals (beta phase)
+
+In priority order:
+
+1. **Grow the TestFlight beta** with the right testers — people who understand "throwaway nsec only" and will file useful reports.
+2. **Educate on NIP-46 / key hygiene** so the market for a signer exists. Most Nostr users still paste their nsec into clients; they don't know there's a problem to solve.
+3. **Recruit client developers** — every row added to `docs/nip46-compatibility.md` is worth more than a hundred likes. The `accounts=multi` extension also needs client adoption before the NIP draft.
+4. **Build trust in the security posture** by being radically honest: open source, audited, but beta — and the proxy's metadata visibility stated plainly.
+
+Explicit non-goal right now: mass-market growth. Clave is beta and pinned to one relay for bunker flow; a viral spike of normies pasting their main nsec in would be a disaster, not a win.
+
+## Channels
+
+| Channel | Role | Who runs it |
+|---|---|---|
+| **Nostr (brand npub)** | Primary. The audience is literally Nostr users, and posting from a Clave-secured account is the product demo. | Volunteer (day-to-day), maintainer (releases, technical threads) |
+| **X/Twitter** | Reach beyond Nostr — bitcoin/privacy crowd, iOS devs. Cross-post the best 2–3 Nostr posts per week. | Volunteer |
+| **GitHub** (releases, Discussions) | Developer channel. Release notes, interop changelog, `accounts=multi` spec discussion. | Maintainer only |
+| **Stacker News / r/nostr** | Occasional long-form: launch-style posts, architecture write-ups. Once or twice a month max. | Maintainer drafts, volunteer can repost |
+| **Nostr dev group chats** (Telegram/SimpleX) | Interop coordination with client devs. Technical, relationship-driven. | Maintainer only |
+
+### Run the brand account through Clave itself
+
+Strongly recommended — this is both the best guardrail and the best marketing story:
+
+1. Create a dedicated **brand npub** (not your personal npub, never the volunteer's key). You hold the nsec in your own Clave install.
+2. The volunteer pairs their Nostr client to your Clave via `bunker://` with **Medium trust**.
+3. Result: the volunteer can post kind-1 notes and replies, but **never sees the key**, can't change the profile (kind 0), can't touch the contact list (kind 3), can't delete events (kind 5) — those are protected kinds that ping you for approval. You get a full audit trail in the activity log, and you can unpair them in one tap if anything goes wrong.
+
+That arrangement *is* the pitch: "our community manager posts from the official account daily and has never seen its private key." Post about it.
+
+(Practical caveat: while bunker flow is pinned to `wss://relay.powr.build`, the volunteer's client needs to support bunker pairing — Nostur is verified. Test the pairing yourselves before handing it over.)
+
+## Cadence & content mix
+
+Realistic for one part-time volunteer: **3–5 Nostr posts/week**, 2–3 cross-posted to X, plus reply engagement. Don't over-commit; a steady drip beats a two-week burst followed by silence.
+
+| Pillar | Share | Examples |
+|---|---|---|
+| **Education** (NIP-46, key hygiene, "why signers") | ~40% | "Your nsec can't be rotated like a password" series; plain-language NIP-46 explainers; the notary analogy |
+| **Product** (features, releases, how-tos) | ~25% | Pairing demo videos (Nostur, fevela.me), release highlights, permission-model walkthroughs, multi-account picker demo |
+| **Community & interop** | ~20% | New verified clients, shout-outs to client devs who fix NIP-46 bugs, compatibility-matrix updates, calls for testers of specific clients |
+| **Engagement** | ~15% | Replies, zapping good answers, boosting ecosystem content (Amber, NIP discussions), polls ("which client should we verify next?") |
+
+Rule of thumb: education and community posts can run on the volunteer's own judgment from the playbook; product claims and anything technical get maintainer review first (the playbook's green/yellow/red matrix covers this).
+
+## First 30 days
+
+**Week 1 — foundation.** Set up brand npub + Clave pairing for the volunteer (the dogfood story above). Publish a pinned "what is Clave" thread (talking-points doc has the copy). Volunteer practices with 2–3 education posts.
+
+**Week 2 — beta recruitment.** TestFlight call-to-action posts — every single one carries the throwaway-nsec caveat, no exceptions. Target Nostur users specifically ("verified ✅"). Short screen recording of bunker pairing → first signed note.
+
+**Week 3 — education series.** "Key hygiene week": one post per day on a single idea (key in N apps = N attack surfaces; keys can't rotate; what a remote signer is; what the proxy can and can't see; how to check per-client permissions). Honest, no FUD about specific clients.
+
+**Week 4 — developer outreach.** Maintainer publishes an `accounts=multi` write-up (Stacker News or GitHub Discussion); volunteer amplifies. Post the interop-issue template link: "found a client that doesn't pair? Tell us, we triage signer-side vs client-side honestly." The four-bucket triage taxonomy from the compatibility doc is genuinely differentiating — most projects blame the other side; you publish the analysis.
+
+After day 30: settle into the steady cadence, one campaign per month (next candidates: per-client demo series, multi-account launch when the NIP draft files, self-hosting story when `docs/SELF-HOSTING.md` lands).
+
+## What success looks like
+
+Track monthly, keep it lightweight:
+
+- TestFlight tester count and weekly-active signers (proxy `/health` gives unique_pubkeys)
+- Verified rows in the compatibility matrix (the single best metric)
+- GitHub: stars, interop issues filed by outsiders, first-time contributors
+- Nostr: follower count on brand npub, zaps/replies per post (vanity-adjacent, weight it least)
+
+## Risks this plan manages
+
+- **Beta over-promotion** → every recruitment post carries the throwaway-nsec caveat; growth is deliberately capped to testers.
+- **Security-claim inflation** → the talking-points doc has an explicit "never say" list; volunteer escalates all security questions beyond the approved FAQ.
+- **Vulnerability reports arriving via social DMs** → playbook has a verbatim redirect-to-SECURITY.md template; volunteer never discusses publicly.
+- **Volunteer account compromise** → volunteer never holds the brand key (Clave pairing model); blast radius is unpair-and-done.

--- a/docs/outreach/talking-points.md
+++ b/docs/outreach/talking-points.md
@@ -1,0 +1,75 @@
+# Clave talking points
+
+_Message reference for anyone posting about Clave. Plain-language first; technical depth at the bottom. The "never say" list at the end is binding for all official posts._
+
+## The one-liner
+
+> **Clave keeps your Nostr key locked in your iPhone's Keychain. Apps ask it for signatures — they never get the key.**
+
+Variations by audience:
+
+- **For Nostr users:** "Stop pasting your nsec into every app. Pair them with Clave instead — one tap, and the app can post as you without ever seeing your key."
+- **For Android-familiar users:** "Amber, for iOS. Same idea — your key lives in one signer app, everything else connects to it — built around iOS's push system instead of Android's background services."
+- **For developers:** "An iOS NIP-46 remote signer that works with the app closed: APNs wakes a Notification Service Extension for ~30 seconds to decrypt, check permissions, sign, and respond. No silent-audio hacks, no foreground requirement."
+- **For privacy folks:** "Open source (MIT), audited, end-to-end encrypted. The push payload is content-free — the server can't read your requests and can't sign as you, because it never has your key."
+
+## The problem (why anyone should care)
+
+1. **Your Nostr key is your identity, and it can't be rotated.** Lose a password, you reset it. Lose your nsec, that identity is gone forever — followers, reputation, DMs, all of it.
+2. **The common practice is pasting that key into every app you try.** Five apps means five copies of the one secret that can never be changed. Any one of them being malicious, buggy, or compromised is game over.
+3. **The existing fixes don't fit iOS.** Browser extensions don't exist on iPhone. Hosted signers mean someone else holds your key. And iOS kills background apps, which is why an Amber-style signer didn't exist here — until now.
+
+## How Clave works, in plain words
+
+The **notary analogy** (use this one — it lands):
+
+> Think of Clave as a notary that lives in your phone. Apps bring documents to be stamped. The notary checks who's asking and what they're asking for, stamps it, and hands it back. **Nobody ever borrows the stamp.**
+
+Slightly more technical, still accessible:
+
+> When an app needs something signed, it sends an encrypted request through a Nostr relay. A small server notices the request and sends your iPhone a push notification — the push contains no readable content, just "something arrived." That push wakes a tiny piece of Clave for about 30 seconds: it decrypts the request, checks the rules **you** set for that app, signs with the key in your Keychain, sends back an encrypted response, and goes back to sleep. The app gets its signature. The key never moved.
+
+**What NIP-46 is** (for "what's NIP-46?" replies): the open Nostr standard for exactly this — apps requesting signatures from a separate signer instead of holding keys themselves. Clave implements it on iOS; Amber implements it on Android; they interoperate with any client that supports the standard. It's not a Clave-proprietary thing, and that's the point.
+
+## Proof points (all verifiable, cite freely)
+
+- **Open source, MIT licensed** — github.com/DocNR/clave. Anyone can read the signing path.
+- **Security audited** (full audit 2026-04-17, before external TestFlight) with automated weekly drift-checks and planned quarterly re-audits.
+- **The key never leaves the device.** iOS Keychain, this-device-only flag — not iCloud-synced, not in backups.
+- **The server can't cheat.** The proxy never holds any key, can't decrypt requests (end-to-end NIP-44 encryption), and can't even register a push token for a pubkey it doesn't own (NIP-98 authenticated registration).
+- **Per-app permissions.** Full/Medium/Low trust per client, per-event-kind overrides, sensitive actions (profile changes, contact list, deletions) require explicit approval. Activity log for everything. One-tap unpair.
+- **Honest interop tracking.** We publish a per-client compatibility matrix and classify every failure as signer-side, client-side, library-shared, or spec-ambiguity — including when the bug is ours.
+- **We dogfood it:** the official Clave account is itself operated through Clave — the person posting has never seen its key. *(Post this only once the pairing in the social plan is actually set up.)*
+
+## Honest caveats (volunteer must know these cold)
+
+State these proactively — credibility is the asset:
+
+- **Beta.** TestFlight only. **Use a throwaway nsec, not your main key.** This caveat goes on every recruitment post, verbatim, no exceptions.
+- **The proxy sees metadata.** It knows which pubkeys have registered devices and when an encrypted request arrived for them. It cannot read contents or sign anything — but "the server sees nothing" would be a false claim. Say "the server sees that a request arrived, never what's in it."
+- **There is currently one proxy and one pinned relay for bunker pairing** (`relay.powr.build`). If it's down, push-wake signing is down. Self-hosting is possible but not yet fully documented; multi-relay support is backlogged.
+- **Client support varies.** Verified: Nostur, fevela.me. Others work with caveats — point people to `docs/nip46-compatibility.md` rather than promising "works with everything."
+- **Same-device pairing on iOS: use the bunker code.** Pasting a client's nostrconnect URI into Clave on the same iPhone is unreliable for reasons outside any signer's control (iOS freezes the client's connection when backgrounded). Bunker flow avoids it entirely.
+
+## Differentiation (compare without trash-talking)
+
+| | Where the key lives | Trade-off to mention |
+|---|---|---|
+| **Clave** | iPhone Keychain, on your device | Beta; depends on a push proxy you can self-host (docs coming) |
+| **Amber** | Android device | The same idea on the other platform — ally, not competitor. Be generous; the Amber comparison legitimizes Clave. |
+| **nsec.app / web signers** | Browser storage | Works today, cross-platform; key sits in a browser context |
+| **nsecBunker / hosted signers** | The operator's server | Convenient; different trust model — you trust the operator with the key |
+| **Pasting nsec into clients** | Every app | The status quo Clave exists to end |
+
+Frame: "different trust models for different people — here's where each puts your key." Never "X is insecure garbage." Other signer projects are allies in making NIP-46 the norm.
+
+## Never say (binding)
+
+- ❌ "Unhackable," "100% secure," "zero-knowledge," "trustless" — security absolutes are wrong and invite hostile attention.
+- ❌ "Ready for your main key" or any recruitment post missing the throwaway-nsec caveat.
+- ❌ "The server sees nothing" — it sees metadata; say what it can't see instead (contents, keys).
+- ❌ "Fully decentralized" — there's currently one proxy and a pinned bunker relay. Say "self-hostable, end-to-end encrypted" instead.
+- ❌ "Works with every Nostr client" — point to the compatibility matrix.
+- ❌ "The audit proves it's safe" — the audit found and fixed issues at a point in time; say "audited, open source, and we keep checking."
+- ❌ Ship dates, feature promises, or "coming soon" for anything not already merged.
+- ❌ Anything negative about a named client or signer project.

--- a/docs/outreach/talking-points.md
+++ b/docs/outreach/talking-points.md
@@ -42,8 +42,8 @@ Slightly more technical, still accessible:
 - **The key never leaves the device.** iOS Keychain, this-device-only flag — not iCloud-synced, not in backups.
 - **The server can't cheat.** The proxy never holds any key, can't decrypt requests (end-to-end NIP-44 encryption), and can't even register a push token for a pubkey it doesn't own (NIP-98 authenticated registration).
 - **Per-app permissions.** Full/Medium/Low trust per client, per-event-kind overrides, sensitive actions (profile changes, contact list, deletions) require explicit approval. Activity log for everything. One-tap unpair.
-- **Multi-account pairing.** Pair a client once and bring all your accounts in — one approval flow, one signer session per account. Clave introduced this as an open extension (`accounts=multi`), validated end-to-end with Spectr (a full-featured Nostr client, testable at https://jank.army), with a NIP draft planned so any signer or client can adopt it.
-- **Works with the clients people actually use.** Verified: Nostur, fevela.me, Spectr, Primal (web), Coracle, Jumble, noStrudel, zap.cooking, YakiHonne.
+- **Multi-account pairing.** Pair a client once and bring all your accounts in — one approval flow, one signer session per account. Clave introduced this as an open extension (`accounts=multi`), validated end-to-end with Jank (a full-featured Nostr client at https://jank.army), with a NIP draft planned so any signer or client can adopt it.
+- **Works with the clients people actually use.** Verified: Nostur, fevela.me, Jank, Primal (web), Coracle, Jumble, noStrudel, zap.cooking, YakiHonne.
 - **Honest interop tracking.** We publish a per-client compatibility matrix and classify every failure as signer-side, client-side, library-shared, or spec-ambiguity — including when the bug is ours.
 - **We dogfood it:** the official Clave account is itself operated through Clave — the person posting has never seen its key. *(Post this only once the pairing in the social plan is actually set up.)*
 

--- a/docs/outreach/talking-points.md
+++ b/docs/outreach/talking-points.md
@@ -9,9 +9,9 @@ _Message reference for anyone posting about Clave. Plain-language first; technic
 Variations by audience:
 
 - **For Nostr users:** "Stop pasting your nsec into every app. Pair them with Clave instead — one tap, and the app can post as you without ever seeing your key."
-- **For Android-familiar users:** "Amber, for iOS. Same idea — your key lives in one signer app, everything else connects to it — built around iOS's push system instead of Android's background services."
+- **For Android-familiar users:** "Amber, for iOS. Same idea — your key lives in one signer app, everything else connects to it. Amber relies on Android's NIP-55 app-to-app intents; iOS has no equivalent and its URL schemes are unreliable, which is exactly why Clave needed a different mechanism — a push-woken extension — to do the same job."
 - **For developers:** "An iOS NIP-46 remote signer that works with the app closed: APNs wakes a Notification Service Extension for ~30 seconds to decrypt, check permissions, sign, and respond. No silent-audio hacks, no foreground requirement."
-- **For privacy folks:** "Open source (MIT), audited, end-to-end encrypted. The push payload is content-free — the server can't read your requests and can't sign as you, because it never has your key."
+- **For privacy folks:** "Open source (MIT), end-to-end encrypted, code open for anyone to audit. The push payload is content-free — the server can't read your requests and can't sign as you, because it never has your key."
 - **For multi-account users:** "Run more than one Nostr identity? Pair an app with Clave once and sign in with all your accounts in a single flow — each one stays a separate key, none of them ever leave your phone."
 
 ## The problem (why anyone should care)
@@ -32,14 +32,17 @@ Slightly more technical, still accessible:
 
 **What NIP-46 is** (for "what's NIP-46?" replies): the open Nostr standard for exactly this — apps requesting signatures from a separate signer instead of holding keys themselves. Clave implements it on iOS; Amber implements it on Android; they interoperate with any client that supports the standard. It's not a Clave-proprietary thing, and that's the point.
 
+**Why iOS needed something new** (for "why not just do what Amber does?"): Amber leans on **NIP-55**, Android's app-to-app intent system, to pass signing requests between a client and the signer locally on-device. iOS has no equivalent — its URL-scheme hand-offs are unreliable and break in standalone PWA mode, and iOS aggressively suspends background apps, so a persistent-connection signer can't run the way Amber does. Clave's push-proxy + Notification Service Extension design exists to route around exactly those constraints. It's not that nobody tried on iOS — it's that the Android approach doesn't survive iOS's rules.
+
 ## Proof points (all verifiable, cite freely)
 
 - **Open source, MIT licensed** — github.com/DocNR/clave. Anyone can read the signing path.
-- **Security audited** (full audit 2026-04-17, before external TestFlight) with automated weekly drift-checks and planned quarterly re-audits.
+- **Open source and security-reviewed.** The full signing path is public and has had an internal security audit (2026-04-17, before external TestFlight) plus automated weekly drift-checks. An independent third-party audit is on the roadmap — it's expensive and depends on funding/time, so we don't claim it's happened until it has.
+- **Proven in real-world use.** Months of daily signing across nine verified clients, not a fresh proof-of-concept.
 - **The key never leaves the device.** iOS Keychain, this-device-only flag — not iCloud-synced, not in backups.
 - **The server can't cheat.** The proxy never holds any key, can't decrypt requests (end-to-end NIP-44 encryption), and can't even register a push token for a pubkey it doesn't own (NIP-98 authenticated registration).
 - **Per-app permissions.** Full/Medium/Low trust per client, per-event-kind overrides, sensitive actions (profile changes, contact list, deletions) require explicit approval. Activity log for everything. One-tap unpair.
-- **Multi-account pairing.** Pair a client once and bring all your accounts in — one approval flow, one signer session per account. Clave introduced this as an open extension (`accounts=multi`), validated end-to-end with Spectr, with a NIP draft planned so any signer or client can adopt it.
+- **Multi-account pairing.** Pair a client once and bring all your accounts in — one approval flow, one signer session per account. Clave introduced this as an open extension (`accounts=multi`), validated end-to-end with Spectr (a full-featured Nostr client, testable at https://jank.army), with a NIP draft planned so any signer or client can adopt it.
 - **Works with the clients people actually use.** Verified: Nostur, fevela.me, Spectr, Primal (web), Coracle, Jumble, noStrudel, zap.cooking, YakiHonne.
 - **Honest interop tracking.** We publish a per-client compatibility matrix and classify every failure as signer-side, client-side, library-shared, or spec-ambiguity — including when the bug is ours.
 - **We dogfood it:** the official Clave account is itself operated through Clave — the person posting has never seen its key. *(Post this only once the pairing in the social plan is actually set up.)*
@@ -48,7 +51,8 @@ Slightly more technical, still accessible:
 
 State these proactively — credibility is the asset:
 
-- **Beta.** TestFlight only. **Use a throwaway nsec, not your main key.** This caveat goes on every recruitment post, verbatim, no exceptions.
+- **It holds your real key — treat it like any app you'd trust with your nsec.** This is the honest framing, not "throwaway only" anymore: putting your key in Clave deserves the same consideration you'd give any signer or client you hand your nsec to. The argument in Clave's favor is the *trade-off* — Clave becomes the single place that holds your key, instead of the many copies you create by pasting your nsec into every client. Fewer attack surfaces, not zero. An independent third-party audit is still on the roadmap; until then, lead with "open source, internally audited, months of real-world use" and let people make an informed call. (New, cautious users pairing a throwaway key first is still a perfectly reasonable suggestion — just not a scolding requirement.)
+- **Still TestFlight beta.** Not on the App Store yet. Say so plainly; don't imply 1.0 stability.
 - **The proxy sees metadata.** It knows which pubkeys have registered devices and when an encrypted request arrived for them. It cannot read contents or sign anything — but "the server sees nothing" would be a false claim. Say "the server sees that a request arrived, never what's in it."
 - **There is currently one proxy and one pinned relay for bunker pairing** (`relay.powr.build`). If it's down, push-wake signing is down. Self-hosting is possible but not yet fully documented; multi-relay support is backlogged.
 - **Client support varies.** Nine clients are verified (list above), but per-client caveats exist — point people to `docs/nip46-compatibility.md` rather than promising "works with everything," and never vouch for a client that isn't on the list.
@@ -58,8 +62,8 @@ State these proactively — credibility is the asset:
 
 | | Where the key lives | Trade-off to mention |
 |---|---|---|
-| **Clave** | iPhone Keychain, on your device | Beta; depends on a push proxy you can self-host (docs coming) |
-| **Amber** | Android device | The same idea on the other platform — ally, not competitor. Be generous; the Amber comparison legitimizes Clave. |
+| **Clave** | iPhone Keychain, on your device | TestFlight beta (months of real-world use); depends on a push proxy you can self-host (docs coming); independent audit still on the roadmap |
+| **Amber** | Android device | The same idea on the other platform — ally, not competitor. Amber uses Android's NIP-55 app-to-app intents; iOS has no equivalent, which is *why* Clave's push-based design exists. Be generous; the Amber comparison legitimizes Clave. |
 | **nsec.app / web signers** | Browser storage | Works today, cross-platform; key sits in a browser context |
 | **nsecBunker / hosted signers** | The operator's server | Convenient; different trust model — you trust the operator with the key |
 | **Pasting nsec into clients** | Every app | The status quo Clave exists to end |
@@ -69,10 +73,10 @@ Frame: "different trust models for different people — here's where each puts y
 ## Never say (binding)
 
 - ❌ "Unhackable," "100% secure," "zero-knowledge," "trustless" — security absolutes are wrong and invite hostile attention.
-- ❌ "Ready for your main key" or any recruitment post missing the throwaway-nsec caveat.
+- ❌ A flat "safe for your main key" *guarantee*. The honest framing is allowed and encouraged: "Clave holds your real key like any signer does — the win is one attack surface instead of many." State the trade-off; don't promise an outcome.
+- ❌ "It's been independently audited" / "the audit proves it's safe" — an internal audit happened; a third-party one hasn't yet. Say "open source, internally audited, independent audit on the roadmap."
 - ❌ "The server sees nothing" — it sees metadata; say what it can't see instead (contents, keys).
 - ❌ "Fully decentralized" — there's currently one proxy and a pinned bunker relay. Say "self-hostable, end-to-end encrypted" instead.
 - ❌ "Works with every Nostr client" — point to the compatibility matrix.
-- ❌ "The audit proves it's safe" — the audit found and fixed issues at a point in time; say "audited, open source, and we keep checking."
 - ❌ Ship dates, feature promises, or "coming soon" for anything not already merged.
 - ❌ Anything negative about a named client or signer project.

--- a/docs/outreach/talking-points.md
+++ b/docs/outreach/talking-points.md
@@ -12,6 +12,7 @@ Variations by audience:
 - **For Android-familiar users:** "Amber, for iOS. Same idea — your key lives in one signer app, everything else connects to it — built around iOS's push system instead of Android's background services."
 - **For developers:** "An iOS NIP-46 remote signer that works with the app closed: APNs wakes a Notification Service Extension for ~30 seconds to decrypt, check permissions, sign, and respond. No silent-audio hacks, no foreground requirement."
 - **For privacy folks:** "Open source (MIT), audited, end-to-end encrypted. The push payload is content-free — the server can't read your requests and can't sign as you, because it never has your key."
+- **For multi-account users:** "Run more than one Nostr identity? Pair an app with Clave once and sign in with all your accounts in a single flow — each one stays a separate key, none of them ever leave your phone."
 
 ## The problem (why anyone should care)
 
@@ -38,6 +39,8 @@ Slightly more technical, still accessible:
 - **The key never leaves the device.** iOS Keychain, this-device-only flag — not iCloud-synced, not in backups.
 - **The server can't cheat.** The proxy never holds any key, can't decrypt requests (end-to-end NIP-44 encryption), and can't even register a push token for a pubkey it doesn't own (NIP-98 authenticated registration).
 - **Per-app permissions.** Full/Medium/Low trust per client, per-event-kind overrides, sensitive actions (profile changes, contact list, deletions) require explicit approval. Activity log for everything. One-tap unpair.
+- **Multi-account pairing.** Pair a client once and bring all your accounts in — one approval flow, one signer session per account. Clave introduced this as an open extension (`accounts=multi`), validated end-to-end with Spectr, with a NIP draft planned so any signer or client can adopt it.
+- **Works with the clients people actually use.** Verified: Nostur, fevela.me, Spectr, Primal (web), Coracle, Jumble, noStrudel, zap.cooking, YakiHonne.
 - **Honest interop tracking.** We publish a per-client compatibility matrix and classify every failure as signer-side, client-side, library-shared, or spec-ambiguity — including when the bug is ours.
 - **We dogfood it:** the official Clave account is itself operated through Clave — the person posting has never seen its key. *(Post this only once the pairing in the social plan is actually set up.)*
 
@@ -48,7 +51,7 @@ State these proactively — credibility is the asset:
 - **Beta.** TestFlight only. **Use a throwaway nsec, not your main key.** This caveat goes on every recruitment post, verbatim, no exceptions.
 - **The proxy sees metadata.** It knows which pubkeys have registered devices and when an encrypted request arrived for them. It cannot read contents or sign anything — but "the server sees nothing" would be a false claim. Say "the server sees that a request arrived, never what's in it."
 - **There is currently one proxy and one pinned relay for bunker pairing** (`relay.powr.build`). If it's down, push-wake signing is down. Self-hosting is possible but not yet fully documented; multi-relay support is backlogged.
-- **Client support varies.** Verified: Nostur, fevela.me. Others work with caveats — point people to `docs/nip46-compatibility.md` rather than promising "works with everything."
+- **Client support varies.** Nine clients are verified (list above), but per-client caveats exist — point people to `docs/nip46-compatibility.md` rather than promising "works with everything," and never vouch for a client that isn't on the list.
 - **Same-device pairing on iOS: use the bunker code.** Pasting a client's nostrconnect URI into Clave on the same iPhone is unreliable for reasons outside any signer's control (iOS freezes the client's connection when backgrounded). Bunker flow avoids it entirely.
 
 ## Differentiation (compare without trash-talking)

--- a/docs/outreach/volunteer-playbook.md
+++ b/docs/outreach/volunteer-playbook.md
@@ -61,12 +61,12 @@ Use these as written or lightly adapted. Where a template says **[escalate]**, s
 > Same idea, different platform: Amber is the Android signer, Clave is the iOS one — and we think Amber is great. The deeper difference is *how* they wake up to sign. Amber uses NIP-55, Android's app-to-app intent system, to pass requests between a client and the signer right on the device. iOS doesn't have that — its app-to-app hand-offs are unreliable and it suspends background apps — so Clave had to take a different route (a push notification that wakes a small signing extension). Both speak the same open standard (NIP-46), so clients that support one generally support the other.
 
 **"Does it work with [client X]?"**
-> If the client is on the verified list — **Nostur, fevela.me, Spectr, Primal (web), Coracle, Jumble, noStrudel, zap.cooking, YakiHonne**: "Yes — verified working."
+> If the client is on the verified list — **Nostur, fevela.me, Jank, Primal (web), Coracle, Jumble, noStrudel, zap.cooking, YakiHonne**: "Yes — verified working."
 > Anything else: "Best place to check is our live compatibility matrix: github.com/DocNR/clave/blob/main/docs/nip46-compatibility.md — and if you try it, tell us what happens, that's exactly the testing we need."
 > Never promise an unlisted client works.
 
 **"Can I use multiple accounts?"**
-> Yes — Clave supports multiple accounts, and with clients that support our multi-account pairing (Spectr today, testable at https://jank.army), you pair once and sign in with all your accounts in a single flow. With other clients, you pair each account separately. Either way, every key stays on your phone.
+> Yes — Clave supports multiple accounts, and with clients that support our multi-account pairing (Jank today, at https://jank.army), you pair once and sign in with all your accounts in a single flow. With other clients, you pair each account separately. Either way, every key stays on your phone.
 
 **"It's not working / pairing fails / requests time out."**
 > Sorry about that — two quick things to try: (1) if the app and Clave are on the same iPhone, pair using Clave's bunker code rather than the app's QR/URI — same-device pairing the other way is unreliable on iOS, not just for us. (2) Make sure notifications are enabled for Clave. If it's still stuck, would you open an issue here so we can dig in? github.com/DocNR/clave/issues — include the client name and what you saw.
@@ -147,9 +147,9 @@ Use as-is or lightly adapted. Recruitment posts (marked ⚠️) should keep the 
 
 11. > Open source, MIT, internally audited, weekly automated security checks — and an independent third-party audit on the roadmap. We tell you exactly where that stands because you shouldn't have to take our word for any of it. github.com/DocNR/clave
 
-12. ⚠️ > Testers wanted: Clave is verified working with Nostur, Primal (web), Coracle, Jumble, noStrudel, Spectr, fevela.me, zap.cooking, and YakiHonne. Pick your favorite, pair it, try to break it, tell us what happens. Still TestFlight beta — go in informed, and if you're cautious, a secondary key is a fine way to start.
+12. ⚠️ > Testers wanted: Clave is verified working with Nostur, Primal (web), Coracle, Jumble, noStrudel, Jank, fevela.me, zap.cooking, and YakiHonne. Pick your favorite, pair it, try to break it, tell us what happens. Still TestFlight beta — go in informed, and if you're cautious, a secondary key is a fine way to start.
 
-13. > One pairing, all your accounts. Clave's multi-account flow lets you connect a client once and sign in with every identity you run — work npub, personal npub, project npub — each key separate, none of them ever leaving your phone. Live today in Spectr (https://jank.army).
+13. > One pairing, all your accounts. Clave's multi-account flow lets you connect a client once and sign in with every identity you run — work npub, personal npub, project npub — each key separate, none of them ever leaving your phone. Live today in Jank (https://jank.army).
 
 ## ⏸️ On hold — do not post until the maintainer explicitly says go
 

--- a/docs/outreach/volunteer-playbook.md
+++ b/docs/outreach/volunteer-playbook.md
@@ -58,7 +58,7 @@ Use these as written or lightly adapted. Where a template says **[escalate]**, s
 > Fair question. iOS suspends background apps, so a signer needs *something* to wake it — Apple's push system is the only reliable mechanism, and that requires a small relay-watching server. It's designed to know as little as possible: it sees that an encrypted request arrived for you, never what's inside. The code is open source and you can run your own. We'd rather be honest about that trade-off than pretend it isn't there.
 
 **"How is this different from Amber?"**
-> Same idea, different platform: Amber is the Android signer, Clave is the iOS one. We think Amber is great — both apps implement the same open standard (NIP-46), so clients that support one generally support the other.
+> Same idea, different platform: Amber is the Android signer, Clave is the iOS one — and we think Amber is great. The deeper difference is *how* they wake up to sign. Amber uses NIP-55, Android's app-to-app intent system, to pass requests between a client and the signer right on the device. iOS doesn't have that — its app-to-app hand-offs are unreliable and it suspends background apps — so Clave had to take a different route (a push notification that wakes a small signing extension). Both speak the same open standard (NIP-46), so clients that support one generally support the other.
 
 **"Does it work with [client X]?"**
 > If the client is on the verified list — **Nostur, fevela.me, Spectr, Primal (web), Coracle, Jumble, noStrudel, zap.cooking, YakiHonne**: "Yes — verified working."
@@ -66,7 +66,7 @@ Use these as written or lightly adapted. Where a template says **[escalate]**, s
 > Never promise an unlisted client works.
 
 **"Can I use multiple accounts?"**
-> Yes — Clave supports multiple accounts, and with clients that support our multi-account pairing (Spectr today), you pair once and sign in with all your accounts in a single flow. With other clients, you pair each account separately. Either way, every key stays on your phone.
+> Yes — Clave supports multiple accounts, and with clients that support our multi-account pairing (Spectr today, testable at https://jank.army), you pair once and sign in with all your accounts in a single flow. With other clients, you pair each account separately. Either way, every key stays on your phone.
 
 **"It's not working / pairing fails / requests time out."**
 > Sorry about that — two quick things to try: (1) if the app and Clave are on the same iPhone, pair using Clave's bunker code rather than the app's QR/URI — same-device pairing the other way is unreliable on iOS, not just for us. (2) Make sure notifications are enabled for Clave. If it's still stuck, would you open an issue here so we can dig in? github.com/DocNR/clave/issues — include the client name and what you saw.
@@ -74,7 +74,7 @@ Use these as written or lightly adapted. Where a template says **[escalate]**, s
 > If they report back that it still fails, or the question gets technical: **[escalate]**.
 
 **"Is it safe? Has it been audited?"**
-> It's open source (MIT) and had a full security audit before the public beta, with ongoing automated checks. That said — it's a **beta**, which is why we ask testers to use a throwaway key, not their main one. We'd rather under-promise here.
+> It's open source (MIT), has had an internal security audit and automated weekly checks, and has been in real-world use for months. An *independent third-party* audit is on the roadmap — it costs real money and time, so we're not going to claim it's done before it is. Honest version: Clave holds your key like any signer does; the win is that it's one app holding it instead of a dozen apps you've pasted your nsec into. We'd rather tell you the trade-off than promise it's bulletproof.
 
 **"When is it on the App Store?" / "When will feature X ship?"**
 > No date to announce — it's on TestFlight while we work through the beta. Follow here and you'll see it the moment that changes.
@@ -84,7 +84,7 @@ Use these as written or lightly adapted. Where a template says **[escalate]**, s
 > Android already has a great signer — Amber. Clave exists because iOS didn't have an equivalent: iOS's background restrictions needed a different architecture (push-based wake-up). One platform, done well.
 
 **"Can I use my real/main nsec?"**
-> Please don't yet — Clave is in beta, and we ask all testers to use a throwaway key. When we're confident enough to change that advice, it'll be announced clearly.
+> You can. The way to think about it: putting your key in Clave deserves the same caution you'd give any app you trust with your nsec — the difference is Clave is *one* place holding it instead of every client you've ever pasted your key into. That's the whole point of a signer: shrink your key's exposure from many apps down to one. It's still TestFlight beta and an independent audit is still on the roadmap, so go in informed. If you're cautious, starting with a secondary key is totally reasonable — just not something we'll scold you about.
 
 **"What data do you collect?"**
 > The proxy stores which pubkeys have a registered device token, and sees when an encrypted request arrives for one. It can't read request contents (end-to-end encrypted) and holds no keys. There are no analytics or trackers in the app. The full security model is public: github.com/DocNR/clave#security-model
@@ -122,17 +122,17 @@ Maintainer contact: _(fill in: Nostr npub + a faster back-channel, e.g. Signal/S
 
 ## Ready-to-post library
 
-Use as-is or lightly adapted. Recruitment posts (marked ⚠️) must keep the throwaway-key line word-for-word.
+Use as-is or lightly adapted. Recruitment posts (marked ⚠️) should keep the "still beta / informed-choice" framing — don't strip the caveat down to a bare "try it," and don't inflate it into a security guarantee.
 
 1. > Your Nostr key isn't a password. Passwords get reset; your nsec can't be. Every app you paste it into is another copy of the one secret you can never change. That's the problem remote signers exist to fix.
 
 2. > Think of Clave as a notary living in your iPhone. Apps bring documents to be stamped — the notary checks who's asking, stamps it, hands it back. Nobody ever borrows the stamp. 🔏
 
-3. ⚠️ > Clave is in open beta on TestFlight — an iOS signer that keeps your Nostr key in the Keychain while your apps sign through it. **It's beta: please use a throwaway key, not your main nsec.** Link in profile.
+3. ⚠️ > Clave is in open beta on TestFlight — an iOS signer that keeps your Nostr key in the Keychain while your apps sign through it. Think of it the way you'd think about any app you trust with your nsec, except this one replaces the dozen others holding copies. Still beta, independent audit on the roadmap — go in informed. Link in profile.
 
 4. > "Doesn't the push server see my stuff?" It sees that an encrypted request arrived for you. It can't read it, can't sign anything, never touches a key. We'd rather explain the trade-off than pretend there isn't one. Full security model is public: github.com/DocNR/clave#security-model
 
-5. > Android has had this for years: Amber holds your key, every app signs through it. Clave is that, for iOS — built on push notifications because iOS kills background apps. Same open standard (NIP-46), so the ecosystem works across both.
+5. > Android has had this for years: Amber holds your key, every app signs through it via NIP-55 intents. iOS has no equivalent — app-to-app hand-offs are unreliable and background apps get suspended — so Clave does the same job a different way: a push notification wakes a tiny signing extension. Same open standard (NIP-46), so the ecosystem works across both.
 
 6. > Pairing tip: if your Nostr app and Clave are on the same iPhone, use Clave's bunker code (Connect → copy/QR) instead of pasting the app's URI into Clave. Same-device pairing the other direction fights iOS itself — bunker flow sidesteps it.
 
@@ -145,19 +145,21 @@ Use as-is or lightly adapted. Recruitment posts (marked ⚠️) must keep the th
 
 10. > What's NIP-46, in one breath: an open standard where apps ask a separate signer for signatures instead of holding your key themselves. Clave on iOS, Amber on Android, others in browsers — one standard, your key in one place.
 
-11. > Open source, MIT, audited before public beta, weekly automated security checks. Not because that makes it perfect — because you shouldn't have to take our word for any of this. github.com/DocNR/clave
+11. > Open source, MIT, internally audited, weekly automated security checks — and an independent third-party audit on the roadmap. We tell you exactly where that stands because you shouldn't have to take our word for any of it. github.com/DocNR/clave
 
-12. ⚠️ > Testers wanted: Clave is verified working with Nostur, Primal (web), Coracle, Jumble, noStrudel, Spectr, fevela.me, zap.cooking, and YakiHonne. Pick your favorite, pair it, try to break it, tell us. **Beta — throwaway key only, please.**
+12. ⚠️ > Testers wanted: Clave is verified working with Nostur, Primal (web), Coracle, Jumble, noStrudel, Spectr, fevela.me, zap.cooking, and YakiHonne. Pick your favorite, pair it, try to break it, tell us what happens. Still TestFlight beta — go in informed, and if you're cautious, a secondary key is a fine way to start.
 
-13. > One pairing, all your accounts. Clave's multi-account flow lets you connect a client once and sign in with every identity you run — work npub, personal npub, project npub — each key separate, none of them ever leaving your phone. Live today in Spectr.
+13. > One pairing, all your accounts. Clave's multi-account flow lets you connect a client once and sign in with every identity you run — work npub, personal npub, project npub — each key separate, none of them ever leaving your phone. Live today in Spectr (https://jank.army).
 
 ## ⏸️ On hold — do not post until the maintainer explicitly says go
 
-The "throwaway key only" guidance is expected to soften as the beta matures. When (and only when) the maintainer gives the go-ahead, this is the transition announcement — until then, every caveat in this playbook stays exactly as written:
+The next big trust milestone is the **independent third-party security audit** (on the roadmap; it depends on funding and time). When — and only when — that audit completes and the maintainer gives the go-ahead, this is the announcement. Until then, never imply the third-party audit has happened.
 
-> Update on key guidance: since launch we've asked beta testers to use a throwaway key. As of build ___, with [audit/milestone — maintainer fills in], we're comfortable saying Clave is ready for daily-driver use. If you've been waiting to bring your main npub — this is the post. As always: your key never leaves your phone, and the code is open for anyone to verify. github.com/DocNR/clave
+> Big one: Clave has now completed an independent third-party security audit by [firm — maintainer fills in]. The report is public at [link]. Open source from day one, internally audited, in real-world use for months, and now externally reviewed too. Your key has always stayed on your phone — now there's one more set of eyes confirming the how. github.com/DocNR/clave
 
-After it's posted, the maintainer will tell you which FAQ replies and library posts to update — don't edit them yourself.
+After it's posted, the maintainer will tell you which FAQ replies and library posts to update (the "independent audit on the roadmap" wording becomes "independently audited") — don't edit them yourself.
+
+> **Note on key guidance:** the earlier "throwaway key only" rule has been retired. Current guidance is the informed-choice framing throughout this doc — Clave holds your real key like any signer, the benefit is one attack surface instead of many. If the maintainer ever wants to tighten this back up (e.g. a security concern surfaces), that's a 🔴 red-zone change — don't soften or harden the key messaging on your own initiative.
 
 ## Weekly rhythm (suggested)
 

--- a/docs/outreach/volunteer-playbook.md
+++ b/docs/outreach/volunteer-playbook.md
@@ -61,9 +61,12 @@ Use these as written or lightly adapted. Where a template says **[escalate]**, s
 > Same idea, different platform: Amber is the Android signer, Clave is the iOS one. We think Amber is great — both apps implement the same open standard (NIP-46), so clients that support one generally support the other.
 
 **"Does it work with [client X]?"**
-> If the client is **Nostur or fevela.me**: "Yes — verified working."
+> If the client is on the verified list — **Nostur, fevela.me, Spectr, Primal (web), Coracle, Jumble, noStrudel, zap.cooking, YakiHonne**: "Yes — verified working."
 > Anything else: "Best place to check is our live compatibility matrix: github.com/DocNR/clave/blob/main/docs/nip46-compatibility.md — and if you try it, tell us what happens, that's exactly the testing we need."
 > Never promise an unlisted client works.
+
+**"Can I use multiple accounts?"**
+> Yes — Clave supports multiple accounts, and with clients that support our multi-account pairing (Spectr today), you pair once and sign in with all your accounts in a single flow. With other clients, you pair each account separately. Either way, every key stays on your phone.
 
 **"It's not working / pairing fails / requests time out."**
 > Sorry about that — two quick things to try: (1) if the app and Clave are on the same iPhone, pair using Clave's bunker code rather than the app's QR/URI — same-device pairing the other way is unreliable on iOS, not just for us. (2) Make sure notifications are enabled for Clave. If it's still stuck, would you open an issue here so we can dig in? github.com/DocNR/clave/issues — include the client name and what you saw.
@@ -144,7 +147,17 @@ Use as-is or lightly adapted. Recruitment posts (marked ⚠️) must keep the th
 
 11. > Open source, MIT, audited before public beta, weekly automated security checks. Not because that makes it perfect — because you shouldn't have to take our word for any of this. github.com/DocNR/clave
 
-12. ⚠️ > Testers wanted: if you use Nostur on iOS, pairing with Clave is verified working end-to-end. Try it, break it, tell us. **Beta — throwaway key only, please.**
+12. ⚠️ > Testers wanted: Clave is verified working with Nostur, Primal (web), Coracle, Jumble, noStrudel, Spectr, fevela.me, zap.cooking, and YakiHonne. Pick your favorite, pair it, try to break it, tell us. **Beta — throwaway key only, please.**
+
+13. > One pairing, all your accounts. Clave's multi-account flow lets you connect a client once and sign in with every identity you run — work npub, personal npub, project npub — each key separate, none of them ever leaving your phone. Live today in Spectr.
+
+## ⏸️ On hold — do not post until the maintainer explicitly says go
+
+The "throwaway key only" guidance is expected to soften as the beta matures. When (and only when) the maintainer gives the go-ahead, this is the transition announcement — until then, every caveat in this playbook stays exactly as written:
+
+> Update on key guidance: since launch we've asked beta testers to use a throwaway key. As of build ___, with [audit/milestone — maintainer fills in], we're comfortable saying Clave is ready for daily-driver use. If you've been waiting to bring your main npub — this is the post. As always: your key never leaves your phone, and the code is open for anyone to verify. github.com/DocNR/clave
+
+After it's posted, the maintainer will tell you which FAQ replies and library posts to update — don't edit them yourself.
 
 ## Weekly rhythm (suggested)
 

--- a/docs/outreach/volunteer-playbook.md
+++ b/docs/outreach/volunteer-playbook.md
@@ -1,0 +1,155 @@
+# Clave official account — volunteer playbook
+
+_This is your operating manual for the official Clave account. It's written so you never need to guess: if a situation isn't covered here, that's a signal to escalate, not improvise. Read [talking-points.md](talking-points.md) alongside this — especially its "Never say" list, which is binding._
+
+## Your access
+
+You post through Clave itself: your client is paired to the official account's signer, with permissions set by the maintainer. You can publish notes and replies. You **cannot** see the account's private key, change its profile, edit its follow list, or delete events — those route to the maintainer for approval. Everything you sign appears in an activity log.
+
+If your own phone or client is ever lost or compromised, tell the maintainer immediately — your pairing gets revoked in one tap and the account is unaffected. This is not a "you're in trouble" event; it's the system working.
+
+## Voice
+
+- **Plain language.** If your non-Nostr friend wouldn't understand the post, rewrite it. "Apps ask for signatures, they never get the key" beats any sentence containing "NIP-46 RPC."
+- **Honest, including about weaknesses.** Beta status, the metadata the server sees, clients that don't work yet — we say these things first, before anyone else does. Credibility is the whole brand.
+- **Warm to everyone, combative with no one.** Zap and boost good community answers. Never dunk on critics, competitors, or confused users.
+- **No hype-speak.** No "revolutionary," no rocket emojis on security claims, no countdown posts.
+
+## What you can post: green / yellow / red
+
+### 🟢 Green — post on your own judgment
+
+- Anything from the ready-to-post library below, lightly adapted
+- Education posts built from talking-points.md (key hygiene, the notary analogy, "what is a remote signer")
+- Boosts/zaps of community posts about Clave, Amber, NIP-46, key safety
+- Replies using the FAQ templates below
+- Polls about preferences ("which client should we test next?")
+- Thank-yous to testers and client developers
+
+### 🟡 Yellow — draft it, get maintainer approval before posting
+
+- Any claim about a specific client working or not working (the matrix changes; your info may be stale)
+- Release/update announcements (maintainer supplies the facts; you make them readable)
+- Replies to threads with significant reach or from prominent accounts
+- Anything responding to criticism of Clave's architecture or security
+- Long-form posts/threads you wrote yourself
+- Cross-posting someone else's technical claims about Clave
+
+### 🔴 Red — never post; escalate immediately
+
+- Anything about security vulnerabilities, real or claimed (see escalation section — this is the big one)
+- Ship dates, roadmaps, feature promises, App Store timing
+- Security guarantees beyond the approved talking points
+- Negative statements about any named project or person
+- Legal, regulatory, or App-Store-policy topics
+- Requests for users' keys, in any form, ever — and never ask users to post screenshots that might contain a key or bunker code
+
+## Replying to common questions
+
+Use these as written or lightly adapted. Where a template says **[escalate]**, send the thread to the maintainer instead of continuing.
+
+**"What is Clave?"**
+> Clave keeps your Nostr key locked in your iPhone's Keychain. Apps you pair with it can ask for signatures — post a note, log in, decrypt a DM — but they never get the key itself. Open source: github.com/DocNR/clave
+
+**"Is my key on your server?"**
+> No — your key never leaves your iPhone's Keychain. Our server's only job is to send your phone a wake-up push when a signing request arrives. The push contains no readable content, and the server can't decrypt requests or sign anything, because it never has any key.
+
+**"Why does it need a server / push notifications at all? Doesn't that make it centralized?"**
+> Fair question. iOS suspends background apps, so a signer needs *something* to wake it — Apple's push system is the only reliable mechanism, and that requires a small relay-watching server. It's designed to know as little as possible: it sees that an encrypted request arrived for you, never what's inside. The code is open source and you can run your own. We'd rather be honest about that trade-off than pretend it isn't there.
+
+**"How is this different from Amber?"**
+> Same idea, different platform: Amber is the Android signer, Clave is the iOS one. We think Amber is great — both apps implement the same open standard (NIP-46), so clients that support one generally support the other.
+
+**"Does it work with [client X]?"**
+> If the client is **Nostur or fevela.me**: "Yes — verified working."
+> Anything else: "Best place to check is our live compatibility matrix: github.com/DocNR/clave/blob/main/docs/nip46-compatibility.md — and if you try it, tell us what happens, that's exactly the testing we need."
+> Never promise an unlisted client works.
+
+**"It's not working / pairing fails / requests time out."**
+> Sorry about that — two quick things to try: (1) if the app and Clave are on the same iPhone, pair using Clave's bunker code rather than the app's QR/URI — same-device pairing the other way is unreliable on iOS, not just for us. (2) Make sure notifications are enabled for Clave. If it's still stuck, would you open an issue here so we can dig in? github.com/DocNR/clave/issues — include the client name and what you saw.
+>
+> If they report back that it still fails, or the question gets technical: **[escalate]**.
+
+**"Is it safe? Has it been audited?"**
+> It's open source (MIT) and had a full security audit before the public beta, with ongoing automated checks. That said — it's a **beta**, which is why we ask testers to use a throwaway key, not their main one. We'd rather under-promise here.
+
+**"When is it on the App Store?" / "When will feature X ship?"**
+> No date to announce — it's on TestFlight while we work through the beta. Follow here and you'll see it the moment that changes.
+> (Never speculate, even casually, even in DMs.)
+
+**"Why iOS only? Android version?"**
+> Android already has a great signer — Amber. Clave exists because iOS didn't have an equivalent: iOS's background restrictions needed a different architecture (push-based wake-up). One platform, done well.
+
+**"Can I use my real/main nsec?"**
+> Please don't yet — Clave is in beta, and we ask all testers to use a throwaway key. When we're confident enough to change that advice, it'll be announced clearly.
+
+**"What data do you collect?"**
+> The proxy stores which pubkeys have a registered device token, and sees when an encrypted request arrives for one. It can't read request contents (end-to-end encrypted) and holds no keys. There are no analytics or trackers in the app. The full security model is public: github.com/DocNR/clave#security-model
+
+**"This architecture is flawed because…" (technical criticism)**
+> Genuinely interested in this — would you open an issue so the right people see it? github.com/DocNR/clave/issues
+> Then **[escalate]**. Don't debate architecture, even if you think you know the answer.
+
+**Trolling / bad faith / "all signers are scams":**
+> One factual, friendly reply maximum, then disengage. Never delete-and-block without checking with the maintainer first. If it gets personal or persistent: **[escalate]**.
+
+## 🚨 Security reports — the one rule that matters most
+
+If anyone — public reply, DM, vague hint — claims to have found a security problem, a way to steal keys, a way to forge signatures, *anything* in that family:
+
+1. **Do not discuss it publicly. Do not ask for details. Do not confirm or deny anything.**
+2. Reply (or DM back) exactly this:
+   > Thank you for flagging this — security reports get priority handling through a private channel so they're fixed before details are public. Please use the contacts in github.com/DocNR/clave/blob/main/SECURITY.md (Nostr DM or email). The maintainer responds within 3 days.
+3. **Immediately** forward the thread/DM to the maintainer, even if it looks like nonsense. Maintainer decides what's real.
+
+This applies even if the person is posting details publicly already. You never add commentary — your only public move is the redirect above.
+
+## Escalation quick reference
+
+| Situation | Action |
+|---|---|
+| Security claim of any kind | Template above + forward to maintainer **immediately** |
+| Bug report you can't resolve with the FAQ | Point to GitHub issues, forward thread to maintainer |
+| Press, podcast, partnership, or business inquiry | "Passing this to the maintainer — expect a reply soon" + forward |
+| Question not covered in this doc | Don't improvise — ask maintainer, reply after |
+| Prominent account engaging (positive or negative) | Forward before replying |
+| You posted something wrong | Tell maintainer first, then correct publicly with a plain "correction:" note. Mistakes are fine; cover-ups are not. |
+
+Maintainer contact: _(fill in: Nostr npub + a faster back-channel, e.g. Signal/SimpleX)_. Expected response time: _(fill in)_. If unreachable and the situation is in the red zone: post nothing. Silence is always safe; a wrong official statement is not.
+
+## Ready-to-post library
+
+Use as-is or lightly adapted. Recruitment posts (marked ⚠️) must keep the throwaway-key line word-for-word.
+
+1. > Your Nostr key isn't a password. Passwords get reset; your nsec can't be. Every app you paste it into is another copy of the one secret you can never change. That's the problem remote signers exist to fix.
+
+2. > Think of Clave as a notary living in your iPhone. Apps bring documents to be stamped — the notary checks who's asking, stamps it, hands it back. Nobody ever borrows the stamp. 🔏
+
+3. ⚠️ > Clave is in open beta on TestFlight — an iOS signer that keeps your Nostr key in the Keychain while your apps sign through it. **It's beta: please use a throwaway key, not your main nsec.** Link in profile.
+
+4. > "Doesn't the push server see my stuff?" It sees that an encrypted request arrived for you. It can't read it, can't sign anything, never touches a key. We'd rather explain the trade-off than pretend there isn't one. Full security model is public: github.com/DocNR/clave#security-model
+
+5. > Android has had this for years: Amber holds your key, every app signs through it. Clave is that, for iOS — built on push notifications because iOS kills background apps. Same open standard (NIP-46), so the ecosystem works across both.
+
+6. > Pairing tip: if your Nostr app and Clave are on the same iPhone, use Clave's bunker code (Connect → copy/QR) instead of pasting the app's URI into Clave. Same-device pairing the other direction fights iOS itself — bunker flow sidesteps it.
+
+7. > You decide what each app is allowed to do. Posting notes? Fine. Changing your profile, editing your follow list, deleting events? Those need your explicit tap, every time. Per-app permissions + an activity log of every request.
+
+8. > Fun fact: this account runs on Clave. The person typing this has never seen its private key — their client is paired with permission to post, and nothing else. That's the product.
+   _(⚠️ Only after the maintainer confirms the pairing is actually set up this way.)_
+
+9. > We publish an honest compatibility matrix for every client we test — including when the bug is on our side. Signer-side, client-side, library bug, or spec ambiguity: we say which. github.com/DocNR/clave/blob/main/docs/nip46-compatibility.md
+
+10. > What's NIP-46, in one breath: an open standard where apps ask a separate signer for signatures instead of holding your key themselves. Clave on iOS, Amber on Android, others in browsers — one standard, your key in one place.
+
+11. > Open source, MIT, audited before public beta, weekly automated security checks. Not because that makes it perfect — because you shouldn't have to take our word for any of this. github.com/DocNR/clave
+
+12. ⚠️ > Testers wanted: if you use Nostur on iOS, pairing with Clave is verified working end-to-end. Try it, break it, tell us. **Beta — throwaway key only, please.**
+
+## Weekly rhythm (suggested)
+
+- **Mon:** education post (pillar content from talking points)
+- **Wed:** product/how-to or community shout-out
+- **Fri:** lighter post — poll, dogfood note, boost of ecosystem content
+- **Daily, ~15 min:** scan mentions/replies, answer from FAQ, forward anything yellow/red
+- **Weekly:** short note to maintainer — what people asked, what confused them, what's resonating. Confused-user questions are product feedback; that loop is half the value of this role.


### PR DESCRIPTION
Adds `docs/outreach/` with three documents for beta-phase outreach, plus a refresh of the README/integrations status to match build 99.

## New docs
- **`social-media-plan.md`** — maintainer-facing strategy: goals, channels (with current infra status), content mix, a 30-day plan, metrics, and risk management.
- **`talking-points.md`** — message reference for anyone posting: per-audience one-liners, the notary analogy, the NIP-55/iOS distinction vs Amber, verifiable proof points, honest caveats, and a binding "never say" list.
- **`volunteer-playbook.md`** — handoff doc for a non-technical volunteer running the official account: green/yellow/red posting matrix, FAQ reply templates, security-report escalation protocol, a ready-to-post library, and a weekly rhythm.

## Doc accuracy updates
- README status section refreshed to build-99 reality: nine verified clients, multi-account / `accounts=multi`, NIP-44 v3 context-aware approvals, incoming signature verification, and the updated NIP-46 method list.
- Key guidance moved from "throwaway key only" to an informed-choice framing (one attack surface vs. many); audit claims corrected to "internally audited, independent third-party audit on the roadmap."
- Client referred to as **Jank** (jank.army) in user-facing copy; Spectr↔Jank codebase/app relationship clarified in `integrations.md`.

Docs only — no code changes. Escalation contact details are intentionally left as blanks to be filled in privately rather than committed.

https://claude.ai/code/session_01WD3kGxmTfiSD7e17i5FjuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WD3kGxmTfiSD7e17i5FjuZ)_