### PR TITLE
docs: plainer pairing FAQ answer + FAQ-launch social post

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -41,8 +41,12 @@ Privately, please — not via a public GitHub issue. See [SECURITY.md](SECURITY.
 **Which Nostr clients work with Clave?**
 Verified working today: Nostur, Primal (web), Coracle, Jumble, noStrudel, Jank, fevela.me, zap.cooking, and YakiHonne. Others may work too — the live, honest compatibility matrix (including known per-client quirks) is at [docs/nip46-compatibility.md](docs/nip46-compatibility.md). If you try a client that isn't listed, tell us what happens.
 
-**Pairing isn't working — what should I check?**
-Two common fixes: (1) If the client app and Clave are on the *same* iPhone, pair using Clave's **bunker code** (Connect → copy or scan the QR) rather than pasting the client's URI into Clave — same-device pairing the other direction is unreliable on iOS for reasons no signer can fully fix. (2) Make sure notifications are enabled for Clave. If it's still stuck, [open an issue](https://github.com/DocNR/clave/issues) with the client name and what you saw.
+**My Nostr app won't connect to Clave — what should I check?**
+A few things to try, in order:
+
+1. **Start the connection from Clave, not from the other app.** Open Clave, tap **Connect**, and copy the code it shows you (or scan its QR code). Then paste or scan that into your Nostr app, usually under an option like "log in with a remote signer," "connect bunker," or "Nostr Connect." Going this direction is the most reliable — especially when Clave and your Nostr app are on the *same* iPhone, where starting from the other app tends to fail for technical reasons no signer can fully work around.
+2. **Make sure Clave is allowed to send notifications.** Clave wakes up to sign when it receives a notification, so if notifications are switched off it can't respond. Open **iOS Settings → Notifications → Clave** and turn them on.
+3. **Still stuck?** [Tell us what happened](https://github.com/DocNR/clave/issues) — include the name of the app you were trying to connect and what you saw on screen. That's exactly what we need to help.
 
 **Can I use more than one account?**
 Yes. Clave holds multiple keys and lets you switch between them. With clients that support our multi-account pairing — [Jank](https://jank.army) today — you pair once and sign in with all your accounts in a single flow; with other clients you pair each account separately. Either way, every key stays on your phone.

--- a/docs/outreach/volunteer-playbook.md
+++ b/docs/outreach/volunteer-playbook.md
@@ -151,6 +151,15 @@ Use as-is or lightly adapted. Recruitment posts (marked ⚠️) should keep the 
 
 13. > One pairing, all your accounts. Clave's multi-account flow lets you connect a client once and sign in with every identity you run — work npub, personal npub, project npub — each key separate, none of them ever leaving your phone. Live today in Jank (https://jank.army).
 
+14. > "But where does my key actually go?" — the question we get most about Clave. So we wrote a plain-language FAQ. A preview:
+   >
+   > • Is my key on your server? No. Your nsec never leaves your iPhone. Our server just nudges your phone "you've got a request" — it can't read anything or sign as you.
+   > • Why iOS only? Android has Amber; iOS had no equivalent, because Apple's background rules block the way Amber works. Clave is built around them.
+   > • Should I use my main key? Your call — the honest version is in the FAQ. The short of it: it's one app holding your key instead of the dozen you've pasted it into.
+   >
+   > Full FAQ, no jargon → github.com/DocNR/clave/blob/main/FAQ.md
+   _(Swap the link for clave.casa/faq if/when the FAQ is hosted on the site. Shorter X variant in the chat handoff.)_
+
 ## ⏸️ On hold — do not post until the maintainer explicitly says go
 
 The next big trust milestone is the **independent third-party security audit** (on the roadmap; it depends on funding and time). When — and only when — that audit completes and the maintainer gives the go-ahead, this is the announcement. Until then, never imply the third-party audit has happened.


### PR DESCRIPTION
Two small docs changes:

1. **Plainer pairing FAQ.** Rewrote "Pairing isn't working" → "My Nostr app won't connect to Clave" for non-technical readers: numbered steps, dropped jargon ("client", "URI"), an explicit iOS Settings path for notifications, and a friendlier "tell us what happened" support step. Same substance (start from Clave's bunker code; enable notifications; report with details), clearer delivery.
2. **FAQ-launch social post.** Added post #14 to the volunteer playbook's ready-to-post library — previews three Q&As and CTAs to the full FAQ.

Docs only — no code changes.

https://claude.ai/code/session_01WD3kGxmTfiSD7e17i5FjuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WD3kGxmTfiSD7e17i5FjuZ)_